### PR TITLE
feat: Added an HOC to sort the models in the table

### DIFF
--- a/frontend/src/modeldirectory/ModelDirectory.test.tsx
+++ b/frontend/src/modeldirectory/ModelDirectory.test.tsx
@@ -160,7 +160,7 @@ describe('ModelDirectory Render', () => {
     expect(modelsTable).toBeInTheDocument();
 
     // AND the ModelsTable should receive the correct default props.
-    expect(ModelsTable).toHaveBeenNthCalledWith(1, {models: [], isLoading: true}, {});
+    expect(ModelsTable).toHaveBeenNthCalledWith(1, {models: [], isLoading: true, requestSort: expect.any(Function),}, {});
 
     // AND WHEN the ModelInfoService resolves
     await waitFor(() => {
@@ -169,7 +169,7 @@ describe('ModelDirectory Render', () => {
     });
     // AND the ModelsTable should re-render with the resolved data and the loading prop should be set to false
     await waitFor(() => {
-      expect(ModelsTable).toHaveBeenNthCalledWith(2, {models: givenMockData, isLoading: false}, expect.anything());
+      expect(ModelsTable).toHaveBeenNthCalledWith(2, {models: givenMockData, isLoading: false, requestSort: expect.any(Function)}, expect.anything());
     });
   });
 
@@ -190,7 +190,7 @@ describe('ModelDirectory Render', () => {
     const modelsTable = screen.getByTestId(MODELS_TABLE_DATA_TEST_ID.MODELS_TABLE_ID);
     expect(modelsTable).toBeInTheDocument();
     // AND the ModelsTable should receive the correct default props.
-    expect(ModelsTable).toHaveBeenCalledWith({models: [], isLoading: true}, {});
+    expect(ModelsTable).toHaveBeenCalledWith({models: [], isLoading: true, requestSort: expect.any(Function)}, {});
 
     // AND WHEN the ModelInfoService fails
     await waitFor(() => {
@@ -198,7 +198,7 @@ describe('ModelDirectory Render', () => {
       expect(useSnackbar().enqueueSnackbar).toHaveBeenCalledWith(`Failed to fetch the models. Please check your internet connection.`, {variant: 'error'});
     });
     // AND the ModelsTable props to remain the same
-    expect(ModelsTable).toHaveBeenCalledWith({models: [], isLoading: true}, {});
+    expect(ModelsTable).toHaveBeenCalledWith({models: [], isLoading: true, requestSort: expect.any(Function)}, {});
     // AND the ModelsTable should not be re-rendered
     expect(ModelsTable).toHaveBeenCalledTimes(1);
   });
@@ -228,12 +228,12 @@ describe('ModelDirectory Render', () => {
     const modelsTable = screen.getByTestId(MODELS_TABLE_DATA_TEST_ID.MODELS_TABLE_ID);
     expect(modelsTable).toBeInTheDocument();
     // AND the ModelsTable should receive the correct default props
-    expect(ModelsTable).toHaveBeenNthCalledWith(1, {models: [], isLoading: true}, {});
+    expect(ModelsTable).toHaveBeenNthCalledWith(1, {models: [], isLoading: true, requestSort: expect.any(Function)}, {});
     // AND WHEN the ModelInfoService succeeds at first
     jest.advanceTimersToNextTimer();
     await waitFor(() => {
       // THEN expect the ModelsTable to have been called with the correct props
-      expect(ModelsTable).toHaveBeenNthCalledWith(2, {models: givenMockData, isLoading: false}, expect.anything());
+      expect(ModelsTable).toHaveBeenNthCalledWith(2, {models: givenMockData, isLoading: false, requestSort: expect.any(Function)}, expect.anything());
     });
     // AND WHEN the ModelInfoService fails
     jest.advanceTimersToNextTimer();
@@ -242,7 +242,7 @@ describe('ModelDirectory Render', () => {
       expect(useSnackbar().enqueueSnackbar).toHaveBeenCalledWith(`Failed to fetch the models. Please check your internet connection.`, {variant: 'error'});
     });
     // AND the ModelsTable to have been called with the previous props
-    expect(ModelsTable).toHaveBeenLastCalledWith({models: givenMockData, isLoading: false}, {});
+    expect(ModelsTable).toHaveBeenLastCalledWith({models: givenMockData, isLoading: false, requestSort: expect.any(Function)}, {});
   });
 
   test('should clear the timer when the ModelDirectory is unmounted', async () => {
@@ -360,7 +360,7 @@ describe('ModelDirectory.ImportDialog action tests', () => {
     expect(modelsTable).toBeInTheDocument();
     await waitFor(() => {
       expect(ModelsTable).toHaveBeenCalledWith({
-        models: expect.arrayContaining([givenNewModel]), isLoading: expect.any(Boolean),
+        models: expect.arrayContaining([givenNewModel]), isLoading: expect.any(Boolean), requestSort: expect.any(Function)
       }, expect.anything());
     });
 
@@ -426,7 +426,7 @@ describe('ModelDirectory.ImportDialog action tests', () => {
     expect(useSnackbar().enqueueSnackbar).toHaveBeenCalledWith(`The model '${givenImportData.name}' import could not be started. Please try again.`, {variant: 'error'});
   });
 
-  test.each([[' has no existing models', []], [' has N existing models', getArrayOfRandomModelsMaxLength(3),],])('should add the new model to the table that %s', async (desc, givenExistingModels) => {
+  test.each([[' has no existing models', []], [' has N existing models', getArrayOfRandomModelsMaxLength(1),],])('should add the new model to the table that %s', async (desc, givenExistingModels) => {
     // GIVEN the ModelDirectory is rendered with some existing models
     jest
       .spyOn(ModelInfoService.prototype, 'fetchAllModelsPeriodically')
@@ -462,7 +462,7 @@ describe('ModelDirectory.ImportDialog action tests', () => {
     expect(modelsTable).toBeInTheDocument();
     await waitFor(() => {
       expect(ModelsTable).toHaveBeenLastCalledWith({
-        models: [givenNewModel, ...givenExistingModels], isLoading: false,
+        models: [givenNewModel, ...givenExistingModels], isLoading: false, requestSort: expect.any(Function)
       }, expect.anything());
     });
   });

--- a/frontend/src/modeldirectory/ModelDirectory.test.tsx
+++ b/frontend/src/modeldirectory/ModelDirectory.test.tsx
@@ -160,7 +160,7 @@ describe('ModelDirectory Render', () => {
     expect(modelsTable).toBeInTheDocument();
 
     // AND the ModelsTable should receive the correct default props.
-    expect(ModelsTable).toHaveBeenNthCalledWith(1, {models: [], isLoading: true, requestSort: expect.any(Function),}, {});
+    expect(ModelsTable).toHaveBeenNthCalledWith(1, expect.objectContaining({models: [], isLoading: true}), expect.anything());
 
     // AND WHEN the ModelInfoService resolves
     await waitFor(() => {
@@ -169,7 +169,7 @@ describe('ModelDirectory Render', () => {
     });
     // AND the ModelsTable should re-render with the resolved data and the loading prop should be set to false
     await waitFor(() => {
-      expect(ModelsTable).toHaveBeenNthCalledWith(2, {models: givenMockData, isLoading: false, requestSort: expect.any(Function)}, expect.anything());
+      expect(ModelsTable).toHaveBeenNthCalledWith(2, expect.objectContaining({models: givenMockData, isLoading: false}), expect.anything());
     });
   });
 
@@ -190,7 +190,7 @@ describe('ModelDirectory Render', () => {
     const modelsTable = screen.getByTestId(MODELS_TABLE_DATA_TEST_ID.MODELS_TABLE_ID);
     expect(modelsTable).toBeInTheDocument();
     // AND the ModelsTable should receive the correct default props.
-    expect(ModelsTable).toHaveBeenCalledWith({models: [], isLoading: true, requestSort: expect.any(Function)}, {});
+    expect(ModelsTable).toHaveBeenCalledWith(expect.objectContaining({models: [], isLoading: true}), expect.anything());
 
     // AND WHEN the ModelInfoService fails
     await waitFor(() => {
@@ -198,7 +198,7 @@ describe('ModelDirectory Render', () => {
       expect(useSnackbar().enqueueSnackbar).toHaveBeenCalledWith(`Failed to fetch the models. Please check your internet connection.`, {variant: 'error'});
     });
     // AND the ModelsTable props to remain the same
-    expect(ModelsTable).toHaveBeenCalledWith({models: [], isLoading: true, requestSort: expect.any(Function)}, {});
+    expect(ModelsTable).toHaveBeenCalledWith(expect.objectContaining({models: [], isLoading: true}), expect.anything());
     // AND the ModelsTable should not be re-rendered
     expect(ModelsTable).toHaveBeenCalledTimes(1);
   });
@@ -228,12 +228,12 @@ describe('ModelDirectory Render', () => {
     const modelsTable = screen.getByTestId(MODELS_TABLE_DATA_TEST_ID.MODELS_TABLE_ID);
     expect(modelsTable).toBeInTheDocument();
     // AND the ModelsTable should receive the correct default props
-    expect(ModelsTable).toHaveBeenNthCalledWith(1, {models: [], isLoading: true, requestSort: expect.any(Function)}, {});
+    expect(ModelsTable).toHaveBeenNthCalledWith(1, expect.objectContaining({models: [], isLoading: true}), expect.anything());
     // AND WHEN the ModelInfoService succeeds at first
     jest.advanceTimersToNextTimer();
     await waitFor(() => {
       // THEN expect the ModelsTable to have been called with the correct props
-      expect(ModelsTable).toHaveBeenNthCalledWith(2, {models: givenMockData, isLoading: false, requestSort: expect.any(Function)}, expect.anything());
+      expect(ModelsTable).toHaveBeenNthCalledWith(2, expect.objectContaining({models: givenMockData, isLoading: false}), expect.anything());
     });
     // AND WHEN the ModelInfoService fails
     jest.advanceTimersToNextTimer();
@@ -242,7 +242,7 @@ describe('ModelDirectory Render', () => {
       expect(useSnackbar().enqueueSnackbar).toHaveBeenCalledWith(`Failed to fetch the models. Please check your internet connection.`, {variant: 'error'});
     });
     // AND the ModelsTable to have been called with the previous props
-    expect(ModelsTable).toHaveBeenLastCalledWith({models: givenMockData, isLoading: false, requestSort: expect.any(Function)}, {});
+    expect(ModelsTable).toHaveBeenLastCalledWith(expect.objectContaining({models: givenMockData, isLoading: false}), expect.anything());
   });
 
   test('should clear the timer when the ModelDirectory is unmounted', async () => {
@@ -359,9 +359,9 @@ describe('ModelDirectory.ImportDialog action tests', () => {
     const modelsTable = screen.getByTestId(MODELS_TABLE_DATA_TEST_ID.MODELS_TABLE_ID);
     expect(modelsTable).toBeInTheDocument();
     await waitFor(() => {
-      expect(ModelsTable).toHaveBeenCalledWith({
-        models: expect.arrayContaining([givenNewModel]), isLoading: expect.any(Boolean), requestSort: expect.any(Function)
-      }, expect.anything());
+      expect(ModelsTable).toHaveBeenCalledWith(expect.objectContaining({
+        models: expect.arrayContaining([givenNewModel]), isLoading: expect.any(Boolean)
+      }), expect.anything());
     });
 
     // AND the backdrop was eventually hidden
@@ -461,9 +461,9 @@ describe('ModelDirectory.ImportDialog action tests', () => {
     const modelsTable = screen.getByTestId(MODELS_TABLE_DATA_TEST_ID.MODELS_TABLE_ID);
     expect(modelsTable).toBeInTheDocument();
     await waitFor(() => {
-      expect(ModelsTable).toHaveBeenLastCalledWith({
-        models: [givenNewModel, ...givenExistingModels], isLoading: false, requestSort: expect.any(Function)
-      }, expect.anything());
+      expect(ModelsTable).toHaveBeenLastCalledWith(expect.objectContaining({
+        models: [givenNewModel, ...givenExistingModels], isLoading: false
+      }), expect.anything());
     });
   });
 });

--- a/frontend/src/modeldirectory/ModelDirectory.tsx
+++ b/frontend/src/modeldirectory/ModelDirectory.tsx
@@ -36,7 +36,7 @@ const ModelDirectory = () => {
   const [isBackDropShown, setBackDropShown] = React.useState(false);
   const [models, setModels] = React.useState([] as ModelInfoTypes.ModelInfo[]);
   const [isLoadingModels, setIsLoadingModels] = React.useState(true);
-  const sortingState = useState<SortConfig>({ key: 'updatedAt', direction: SortDirection.DESCENDING });
+  const sortingState = useState<SortConfig>({ key: 'updatedAt', direction: SortDirection.DESCENDING});
 
   const {enqueueSnackbar} = useSnackbar()
   const showImportDialog = (b: boolean) => {

--- a/frontend/src/modeldirectory/ModelDirectory.tsx
+++ b/frontend/src/modeldirectory/ModelDirectory.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect} from "react";
+import React, {useCallback, useEffect, useState} from "react";
 import {Box, Button, Container} from '@mui/material';
 import ImportModelDialog, {CloseEvent, ImportData} from "src/import/ImportModelDialog";
 import {ServiceError} from "src/error/error";
@@ -6,11 +6,12 @@ import ImportDirectorService from "src/import/importDirector.service";
 import {useSnackbar} from "src/theme/SnackbarProvider/SnackbarProvider";
 import {writeServiceErrorToLog} from "../error/logger";
 import {Backdrop} from "src/theme/Backdrop/Backdrop";
-import ModelsTable from "./components/modelTables/ModelsTable";
+import SortedModelsTable from "./components/modelTables/ModelsTable";
 import {ModelInfoTypes} from "../modelInfo/modelInfoTypes";
 import ModelInfoService from "src/modelInfo/modelInfo.service";
 import LocaleAPISpecs from "api-specifications/locale"
-import withSorting from "./components/modelTables/withSorting";
+import {SortDirection} from "./components/modelTables/withSorting.types";
+import {SortConfig} from "./components/modelTables/withSorting";
 
 const uniqueId = "8482f1cc-0786-423f-821e-34b6b712d63f"
 export const DATA_TEST_ID = {
@@ -35,6 +36,7 @@ const ModelDirectory = () => {
   const [isBackDropShown, setBackDropShown] = React.useState(false);
   const [models, setModels] = React.useState([] as ModelInfoTypes.ModelInfo[]);
   const [isLoadingModels, setIsLoadingModels] = React.useState(true);
+  const sortingState = useState<SortConfig>({ key: 'updatedAt', direction: SortDirection.DESCENDING });
 
   const {enqueueSnackbar} = useSnackbar()
   const showImportDialog = (b: boolean) => {
@@ -43,6 +45,7 @@ const ModelDirectory = () => {
 
   const handleModelInfoFetch = useCallback(() => {
     return modelInfoService.fetchAllModelsPeriodically((models) => {
+      console.log('polling')
       setModels(models);
       setIsLoadingModels(false);
     }, e => {
@@ -84,8 +87,6 @@ const ModelDirectory = () => {
     }
   };
 
-  const SortedModelsTable = withSorting(ModelsTable);
-
   useEffect(() => {
     const timerId = handleModelInfoFetch();
 
@@ -104,7 +105,7 @@ const ModelDirectory = () => {
           Import Model
         </Button>
       </Box>
-      <SortedModelsTable models={models} isLoading={isLoadingModels}/>
+      <SortedModelsTable models={models} isLoading={isLoadingModels} sortingState={sortingState}/>
     </Box>
     {isImportDlgOpen && <ImportModelDialog isOpen={isImportDlgOpen} availableLocales={availableLocales}
                                            notifyOnClose={handleOnImportDialogClose}/>}

--- a/frontend/src/modeldirectory/ModelDirectory.tsx
+++ b/frontend/src/modeldirectory/ModelDirectory.tsx
@@ -10,6 +10,7 @@ import ModelsTable from "./components/modelTables/ModelsTable";
 import {ModelInfoTypes} from "../modelInfo/modelInfoTypes";
 import ModelInfoService from "src/modelInfo/modelInfo.service";
 import LocaleAPISpecs from "api-specifications/locale"
+import withSorting from "./components/modelTables/withSorting";
 
 const uniqueId = "8482f1cc-0786-423f-821e-34b6b712d63f"
 export const DATA_TEST_ID = {
@@ -65,9 +66,11 @@ const ModelDirectory = () => {
           importData.description,
           importData.locale,
           importData.selectedFiles
-        ) as any;
+        );
         enqueueSnackbar(`The model '${importData.name}' import has started.`, {variant: "success"});
-        setModels([newModel, ...models]);
+        if (!models.some(model => model.UUID === newModel.UUID)) {
+          setModels([newModel, ...models]);
+        }
       } catch (e) {
         enqueueSnackbar(`The model '${importData.name}' import could not be started. Please try again.`, {variant: "error"})
         if (e instanceof ServiceError) {
@@ -80,6 +83,8 @@ const ModelDirectory = () => {
       }
     }
   };
+
+  const SortedModelsTable = withSorting(ModelsTable);
 
   useEffect(() => {
     const timerId = handleModelInfoFetch();
@@ -99,7 +104,7 @@ const ModelDirectory = () => {
           Import Model
         </Button>
       </Box>
-      <ModelsTable models={models} isLoading={isLoadingModels}/>
+      <SortedModelsTable models={models} isLoading={isLoadingModels}/>
     </Box>
     {isImportDlgOpen && <ImportModelDialog isOpen={isImportDlgOpen} availableLocales={availableLocales}
                                            notifyOnClose={handleOnImportDialogClose}/>}

--- a/frontend/src/modeldirectory/components/modelTables/ModelsTable.stories.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/ModelsTable.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react';
 
-import ModelsTable from "./ModelsTable";
+import ModelsTable, {ModelsTableProps} from "./ModelsTable";
 import {
   getArrayOfFakeModels, getArrayOfFakeModelsForSorting,
   getArrayOfFakeModelsMaxLength, getOneFakeModel,
@@ -17,15 +17,17 @@ export default {
   component: ModelsTable,
   tags: ['autodocs'],
   decorators: [
-    (Story) => {
-      const sortingState = useState<SortConfig>({
-        key: 'updatedAt',
-        direction: SortDirection.DESCENDING
-      });
+    (Story, context) => {
+      const DecoratorComponent = () => {
+        const sortingState = useState<SortConfig>({
+          key: 'updatedAt',
+          direction: SortDirection.DESCENDING
+        });
 
-      console.log('Sorting State: ', sortingState);
+        return <ModelsTable sortingState={sortingState} {...context.args as ModelsTableProps}/>;
+      };
 
-      return <Story sortingState={sortingState} />;
+      return <DecoratorComponent />;
     },
   ],
 } as Meta;
@@ -67,6 +69,6 @@ export const ShownWithDifferentImportStates: Story = {
 export const ShownWithSorting: Story = {
   args: {
     models: getArrayOfFakeModelsForSorting(),
-    isLoading: false
+    isLoading: false,
   }
-}
+};

--- a/frontend/src/modeldirectory/components/modelTables/ModelsTable.stories.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/ModelsTable.stories.tsx
@@ -2,21 +2,34 @@ import type {Meta, StoryObj} from '@storybook/react';
 
 import ModelsTable from "./ModelsTable";
 import {
-  getArrayOfFakeModels,
+  getArrayOfFakeModels, getArrayOfFakeModelsForSorting,
   getArrayOfFakeModelsMaxLength, getOneFakeModel,
 } from "./_test_utilities/mockModelData";
 import {
   getAllImportProcessStatePermutations
 } from "../importProcessStateIcon/_test_utilities/importProcesStateTestData";
+import {useState} from "react";
+import {SortConfig} from "./withSorting";
+import {SortDirection} from "./withSorting.types";
 
-const meta: Meta<typeof ModelsTable> = {
+export default {
   title: 'ModelDirectory/ModelsTable',
   component: ModelsTable,
   tags: ['autodocs'],
-  argTypes: {},
-};
+  decorators: [
+    (Story) => {
+      const sortingState = useState<SortConfig>({
+        key: 'updatedAt',
+        direction: SortDirection.DESCENDING
+      });
 
-export default meta;
+      console.log('Sorting State: ', sortingState);
+
+      return <Story sortingState={sortingState} />;
+    },
+  ],
+} as Meta;
+
 type Story = StoryObj<typeof ModelsTable>;
 
 export const Shown: Story = {
@@ -47,6 +60,13 @@ export const ShownWithDifferentImportStates: Story = {
       model.importProcessState = importProcessState;
       return model;
     }),
+    isLoading: false
+  }
+}
+
+export const ShownWithSorting: Story = {
+  args: {
+    models: getArrayOfFakeModelsForSorting(),
     isLoading: false
   }
 }

--- a/frontend/src/modeldirectory/components/modelTables/ModelsTable.test.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/ModelsTable.test.tsx
@@ -1,5 +1,5 @@
 import {render, screen, within} from "@testing-library/react";
-import ModelsTable, {CELL_MAX_LENGTH, DATA_TEST_ID, TEXT} from "./ModelsTable";
+import ModelsTable, {CELL_MAX_LENGTH, DATA_TEST_ID, ModelsTableProps, TEXT} from "./ModelsTable";
 import {getArrayOfRandomModelsMaxLength, getOneRandomModelMaxLength} from "./_test_utilities/mockModelData";
 import * as React from "react";
 import {getRandomLorem} from "src/_test_utilities/specialCharacters";
@@ -43,14 +43,22 @@ jest.mock('src/modeldirectory/components/tableLoadingRows/TableLoadingRows', () 
 });
 
 import TableLoadingRows from "src/modeldirectory/components/tableLoadingRows/TableLoadingRows";
+import {useState} from "react";
+import withSorting, {SortConfig} from "./withSorting";
+import {SortableKeys, SortDirection} from "./withSorting.types";
 
 describe("ModelsTable", () => {
+  const SortedModelsTable = (args: ModelsTableProps) => {
+    const sortingState = useState<SortConfig>({ key: '_' as SortableKeys, direction: SortDirection.DESCENDING });
+    const SortedTable = withSorting(ModelsTable);
+    return <SortedTable {...args} sortingState={sortingState} />;
+  };
   test("should render the table with the models", () => {
     // GIVEN n models with random data of max length
     const givenModels = getArrayOfRandomModelsMaxLength(3);
 
     // WHEN the ModelsTable is rendered with the given models
-    const {container} = render(<ModelsTable models={givenModels}/>);
+    const {container} = render(<SortedModelsTable models={givenModels} />);
 
     // THEN expect the table to be shown
     const tableElement = screen.getByTestId(DATA_TEST_ID.MODELS_TABLE_ID);
@@ -152,7 +160,7 @@ describe("ModelsTable", () => {
 
     // WHEN the ModelsTable is rendered
     // @ts-ignore
-    render(<ModelsTable models={givenModels}/>);
+    render(<SortedModelsTable models={givenModels}/>);
 
     // THEN expect the table to be shown
     const tableElement = screen.getByTestId(DATA_TEST_ID.MODELS_TABLE_ID);
@@ -194,7 +202,7 @@ describe("ModelsTable", () => {
       givenModels[0].released = givenIsReleasedFlag;
 
       // WHEN the ModelsTable is rendered
-      render(<ModelsTable models={givenModels}/>);
+      render(<SortedModelsTable models={givenModels}/>);
 
       // THEN expect the released to be rendered based on the value
       const tableHeader = screen.getByTestId(DATA_TEST_ID.MODEL_TABLE_HEADER_ROW);
@@ -230,7 +238,7 @@ describe("ModelsTable", () => {
       givenModels[0].description = givenDescription;
 
       // WHEN the ModelsTable is rendered
-      render(<ModelsTable models={givenModels}/>);
+      render(<SortedModelsTable models={givenModels}/>);
 
       // THEN expected the description to render based on it's length
       const tableHeader = screen.getByTestId(DATA_TEST_ID.MODEL_TABLE_HEADER_ROW);
@@ -259,7 +267,7 @@ describe("ModelsTable", () => {
       expect(givenModel.importProcessState).toBeDefined();
 
       // WHEN the ModelsTable is rendered with the given model
-      render(<ModelsTable models={[givenModel]}/>);
+      render(<SortedModelsTable models={[givenModel]}/>);
 
       // THEN expect the icon to be shown
       const actualModelCellStatusIconContainer = screen.getByTestId(DATA_TEST_ID.MODEL_CELL_STATUS_ICON_CONTAINER);
@@ -279,7 +287,7 @@ describe("ModelsTable", () => {
       const givenModels: ModelInfoTypes.ModelInfo[] = [];
 
       // WHEN the ModelsTable component is rendered with the given properties
-      render(<ModelsTable models={givenModels} isLoading={givenIsLoading}/>)
+      render(<SortedModelsTable models={givenModels} isLoading={givenIsLoading}/>)
 
       // THEN expect the table to be shown
       const tableElement = screen.getByTestId(DATA_TEST_ID.MODELS_TABLE_ID);
@@ -311,7 +319,7 @@ describe("ModelsTable", () => {
       const givenModels: ModelInfoTypes.ModelInfo[] = getArrayOfRandomModelsMaxLength(3);
 
       // WHEN the ModelsTable component is rendered with the given properties
-      render(<ModelsTable models={givenModels} isLoading={givenIsLoading}/>);
+      render(<SortedModelsTable models={givenModels} isLoading={givenIsLoading}/>);
 
       // THEN expect the table to be shown
       const tableElement = screen.getByTestId(DATA_TEST_ID.MODELS_TABLE_ID);
@@ -332,7 +340,7 @@ describe("ModelsTable", () => {
       const givenModels = getArrayOfRandomModelsMaxLength(3);
 
       // WHEN the ModelsTable component is rendered with the given models
-      render(<ModelsTable models={givenModels}/>);
+      render(<SortedModelsTable models={givenModels}/>);
 
       // THEN expect the given models to be shown
       const modelTableDataRowElements = screen.getAllByTestId(DATA_TEST_ID.MODEL_TABLE_DATA_ROW);

--- a/frontend/src/modeldirectory/components/modelTables/ModelsTable.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/ModelsTable.tsx
@@ -53,7 +53,7 @@ export const DATA_TEST_ID = {
 export const CELL_MAX_LENGTH = 256;
 export const ModelsTable = (props: SortedModelsTableProps) => {
 
-  const sortingState = props?.sortingState?.[0] ?? { key: 'updatedAt', direction: SortDirection.DESCENDING };
+  const sortingState = props.sortingState[0]
   const handleHeaderClick = (key: SortableKeys) => {
       if (props.requestSort) {
         props.requestSort(key);

--- a/frontend/src/modeldirectory/components/modelTables/ModelsTable.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/ModelsTable.tsx
@@ -11,9 +11,12 @@ import TableLoadingRows from "../tableLoadingRows/TableLoadingRows";
 import PublishedWithChangesIcon from '@mui/icons-material/PublishedWithChanges';
 import {Container} from "@mui/material";
 import ImportProcessStateIcon from "../importProcessStateIcon/ImportProcessStateIcon";
-interface ModelsTableProps {
+import {SortableKeys, SortDirection} from "./withSorting.types";
+
+export interface ModelsTableProps {
   models: ModelInfoTypes.ModelInfo[],
   isLoading?: boolean
+  requestSort?: (key: SortableKeys, direction?: SortDirection) => void;
 }
 
 const uniqueId = "ae03cd11-e992-4313-9a9e-49f497cc92d0";

--- a/frontend/src/modeldirectory/components/modelTables/ModelsTable.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/ModelsTable.tsx
@@ -5,13 +5,15 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import {ModelInfoTypes} from "src/modelInfo/modelInfoTypes";
 import TableLoadingRows from "../tableLoadingRows/TableLoadingRows";
 import PublishedWithChangesIcon from '@mui/icons-material/PublishedWithChanges';
-import {Container} from "@mui/material";
+import {Chip, Container} from "@mui/material";
 import ImportProcessStateIcon from "../importProcessStateIcon/ImportProcessStateIcon";
 import {SortableKeys, SortDirection} from "./withSorting.types";
+import withSorting, { SortedModelsTableProps} from "./withSorting";
 
 export interface ModelsTableProps {
   models: ModelInfoTypes.ModelInfo[],
@@ -20,7 +22,6 @@ export interface ModelsTableProps {
 }
 
 const uniqueId = "ae03cd11-e992-4313-9a9e-49f497cc92d0";
-
 export const TEXT = {
   TABLE_HEADER_LABEL_NAME: "Name",
   TABLE_HEADER_LABEL_LOCALE: "Locale",
@@ -29,6 +30,15 @@ export const TEXT = {
   TABLE_HEADER_LABEL_DESCRIPTION: "Description",
   TABLE_HEADER_LABEL_STATUS: ""
 }
+
+const tableHeaders = [
+  { key: 'status', label: TEXT.TABLE_HEADER_LABEL_STATUS, sortable: false },
+  { key: 'name', label: TEXT.TABLE_HEADER_LABEL_NAME, sortable: true },
+  { key: 'locale', label: TEXT.TABLE_HEADER_LABEL_LOCALE, sortable: false },
+  { key: 'version', label: TEXT.TABLE_HEADER_LABEL_VERSION, sortable: true },
+  { key: 'released', label: TEXT.TABLE_HEADER_LABEL_RELEASED, sortable: false },
+  { key: 'description', label: TEXT.TABLE_HEADER_LABEL_DESCRIPTION, sortable: false },
+];
 
 export const DATA_TEST_ID = {
   MODELS_TABLE_ID: `models-table-${uniqueId}`,
@@ -41,26 +51,55 @@ export const DATA_TEST_ID = {
 }
 
 export const CELL_MAX_LENGTH = 256;
-const ModelsTable = (props: ModelsTableProps) => {
+export const ModelsTable = (props: SortedModelsTableProps) => {
+
+  const sortingState = props?.sortingState?.[0] ?? { key: 'updatedAt', direction: SortDirection.DESCENDING };
+  const handleHeaderClick = (key: SortableKeys) => {
+      if (props.requestSort) {
+        props.requestSort(key);
+      }
+    }
 
   return (
     <TableContainer component={Paper} data-testid={DATA_TEST_ID.MODELS_TABLE_ID}>
       <Table tabIndex={0} aria-label="models table">
         <TableHead>
           <TableRow data-testid={DATA_TEST_ID.MODEL_TABLE_HEADER_ROW}>
-            <TableCell variant='body' sx={{fontWeight: "bold"}} data-testid={DATA_TEST_ID.MODEL_CELL}>
-              {TEXT.TABLE_HEADER_LABEL_STATUS}
-            </TableCell>
-            <TableCell  sx={{fontWeight: "bold"}}
-                       data-testid={DATA_TEST_ID.MODEL_CELL}>{TEXT.TABLE_HEADER_LABEL_NAME}</TableCell>
-            <TableCell sx={{fontWeight: "bold"}}
-                       data-testid={DATA_TEST_ID.MODEL_CELL}>{TEXT.TABLE_HEADER_LABEL_LOCALE}</TableCell>
-            <TableCell sx={{fontWeight: "bold"}}
-                       data-testid={DATA_TEST_ID.MODEL_CELL}>{TEXT.TABLE_HEADER_LABEL_VERSION}</TableCell>
-            <TableCell sx={{fontWeight: "bold"}}
-                       data-testid={DATA_TEST_ID.MODEL_CELL}>{TEXT.TABLE_HEADER_LABEL_RELEASED}</TableCell>
-            <TableCell sx={{fontWeight: "bold"}}
-                       data-testid={DATA_TEST_ID.MODEL_CELL}>{TEXT.TABLE_HEADER_LABEL_DESCRIPTION}</TableCell>
+            {
+              tableHeaders.map(header => (
+                <TableCell
+                  key={header.key}
+                  sx={{
+                    fontWeight: "bold",
+                    cursor: header.sortable ? "pointer" : "default"
+                  }}
+                  onClick={() => header.sortable && handleHeaderClick(header.key as SortableKeys)}
+                  data-testid={DATA_TEST_ID.MODEL_CELL}
+                >
+                  {
+                    header.sortable ? (
+                      <Box
+                        sx={{display: 'flex', alignItems: 'center', flexDirection: "row"}}
+                        onClick={() => handleHeaderClick(header.key as SortableKeys)}
+                      >
+                        {header.label}
+                        {sortingState.key === header.key ? (
+                          <Chip size="small" variant="outlined" label={sortingState.direction === SortDirection.DESCENDING ? 'DEC' : 'ASC'} sx={{
+                            marginLeft: "0.5rem",
+                            height: '1.25rem',
+                            padding: '0 0.3125rem',
+                            fontSize: '0.625rem',
+                            borderRadius: '0.2rem',
+                            backgroundColor: 'common.white',
+                            cursor: "pointer"
+                          }}/>
+                        ) : null}
+                      </Box>
+                    ) : header.label
+                  }
+                </TableCell>
+              ))
+            }
           </TableRow>
         </TableHead>
         <TableBody>
@@ -99,4 +138,9 @@ const ModelsTable = (props: ModelsTableProps) => {
     </TableContainer>
   );
 };
-export default ModelsTable;
+
+const SortedModelsTable: React.FC<SortedModelsTableProps> = (props) => {
+  return <ModelsTable {...props} />;
+};
+
+export default withSorting(SortedModelsTable);

--- a/frontend/src/modeldirectory/components/modelTables/_test_utilities/mockModelData.ts
+++ b/frontend/src/modeldirectory/components/modelTables/_test_utilities/mockModelData.ts
@@ -128,6 +128,86 @@ export function getArrayOfRandomModelsMaxLength(number: number): ModelInfoTypes.
   return models
 }
 
+export function getArrayOfFakeModelsForSorting(): ModelInfoTypes.ModelInfo[] {
+  const baseModel: Omit<ModelInfoTypes.ModelInfo, 'name' | 'version' | 'createdAt' | 'updatedAt'> = {
+    id: 'base',
+    UUID: uuidv4(),
+    previousUUID: uuidv4(),
+    originUUID: uuidv4(),
+    locale: {
+      UUID: uuidv4(),
+      name: faker.location.country().substring(0, ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH),
+      shortCode: faker.location.countryCode("alpha-3").substring(0, LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH)
+    },
+    description: getRandomLorem(CELL_MAX_LENGTH / 2),
+    released: true,
+    releaseNotes: faker.lorem.text().substring(0, ModelInfoAPISpecs.Constants.RELEASE_NOTES_MAX_LENGTH),
+    path: faker.internet.url(),
+    tabiyaPath: faker.internet.url(),
+    importProcessState: {
+      id: getMockId(10000),
+      status: getRandomStatus(1),
+      result: {
+        errored: true,
+        parsingErrors: true,
+        parsingWarnings: true,
+      }
+    }
+  };
+
+  return [
+    {
+      ...baseModel,
+      id: '1',
+      name: 'older',
+      version: '1.0.0',
+      createdAt: new Date('2022-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2022-01-01T00:00:00.000Z'),
+    },
+    {
+      ...baseModel,
+      id: '2',
+      name: 'old',
+      version: '1.1.0',
+      createdAt: new Date('2022-01-02T00:00:00.000Z'),
+      updatedAt: new Date('2022-01-02T00:00:00.000Z'),
+    },
+    {
+      ...baseModel,
+      id: '3',
+      name: 'new',
+      version: '1.1.1',
+      createdAt: new Date('2022-01-03T00:00:00.000Z'),
+      updatedAt: new Date('2022-01-03T00:00:00.000Z'),
+    },
+    {
+      ...baseModel,
+      id: '4',
+      name: 'newest',
+      version: '1.1.2',
+      createdAt: new Date('2022-01-04T00:00:00.000Z'),
+      updatedAt: new Date('2022-01-04T00:00:00.000Z'),
+    },
+    {
+      ...baseModel,
+      id: '5',
+      name: 'newer',
+      version: '1.1.3',
+      createdAt: new Date('2022-01-05T00:00:00.000Z'),
+      updatedAt: new Date('2022-01-05T00:00:00.000Z'),
+    },
+    {
+      ...baseModel,
+      id: '6',
+      name: 'ancient',
+      version: '1.0.9',
+      createdAt: new Date('2022-01-06T00:00:00.000Z'),
+      updatedAt: new Date('2022-01-06T00:00:00.000Z'),
+    }
+  ];
+}
+
+
 export function getRandomStatus(id: number) {
   const allStatuses = Object.values(ImportProcessStateAPISpecs.Enums.Status); // Assuming it's an enum with string values
   return allStatuses[id % allStatuses.length];

--- a/frontend/src/modeldirectory/components/modelTables/_test_utilities/mockModelData.ts
+++ b/frontend/src/modeldirectory/components/modelTables/_test_utilities/mockModelData.ts
@@ -159,7 +159,7 @@ export function getArrayOfFakeModelsForSorting(): ModelInfoTypes.ModelInfo[] {
     {
       ...baseModel,
       id: '1',
-      name: 'older',
+      name: 'ancient',
       version: '1.0.0',
       createdAt: new Date('2022-01-01T00:00:00.000Z'),
       updatedAt: new Date('2022-01-01T00:00:00.000Z'),
@@ -167,7 +167,7 @@ export function getArrayOfFakeModelsForSorting(): ModelInfoTypes.ModelInfo[] {
     {
       ...baseModel,
       id: '2',
-      name: 'old',
+      name: 'older',
       version: '1.1.0',
       createdAt: new Date('2022-01-02T00:00:00.000Z'),
       updatedAt: new Date('2022-01-02T00:00:00.000Z'),
@@ -175,7 +175,7 @@ export function getArrayOfFakeModelsForSorting(): ModelInfoTypes.ModelInfo[] {
     {
       ...baseModel,
       id: '3',
-      name: 'new',
+      name: 'old',
       version: '1.1.1',
       createdAt: new Date('2022-01-03T00:00:00.000Z'),
       updatedAt: new Date('2022-01-03T00:00:00.000Z'),
@@ -183,7 +183,7 @@ export function getArrayOfFakeModelsForSorting(): ModelInfoTypes.ModelInfo[] {
     {
       ...baseModel,
       id: '4',
-      name: 'newest',
+      name: 'new',
       version: '1.1.2',
       createdAt: new Date('2022-01-04T00:00:00.000Z'),
       updatedAt: new Date('2022-01-04T00:00:00.000Z'),
@@ -199,8 +199,8 @@ export function getArrayOfFakeModelsForSorting(): ModelInfoTypes.ModelInfo[] {
     {
       ...baseModel,
       id: '6',
-      name: 'ancient',
-      version: '1.0.9',
+      name: 'newest',
+      version: '1.2.2',
       createdAt: new Date('2022-01-06T00:00:00.000Z'),
       updatedAt: new Date('2022-01-06T00:00:00.000Z'),
     }

--- a/frontend/src/modeldirectory/components/modelTables/sortByHeader.ts
+++ b/frontend/src/modeldirectory/components/modelTables/sortByHeader.ts
@@ -1,0 +1,35 @@
+const sortItems = (aValue: any, bValue: any, key: string): number => {
+  let comparison = 0;
+  if (aValue instanceof Date && bValue instanceof Date) {
+    comparison = aValue.getTime() - bValue.getTime();
+  } else if (typeof aValue === 'string' && typeof bValue === 'string') {
+    if (key === 'version') {
+      try {
+        const aVersion = aValue.split('.').map(Number);
+        const bVersion = bValue.split('.').map(Number);
+        for (let i = 0; i < aVersion.length; i++) {
+          if (aVersion[i] > bVersion[i]) {
+            comparison = 1;
+            break;
+          } else if (aVersion[i] < bVersion[i]) {
+            comparison = -1;
+            break;
+          }
+        }
+      } catch (err: any) {
+        console.warn(`Invalid version format for key ${key}`);
+      }
+    } else {
+      try {
+        comparison = aValue.localeCompare(bValue);
+      } catch (err: any) {
+        console.warn(`Unsupported sort comparison for key ${key}`);
+      }
+    }
+  } else {
+    console.warn(`Unsupported sort comparison for key ${key}`);
+  }
+  return comparison;
+};
+
+export default sortItems;

--- a/frontend/src/modeldirectory/components/modelTables/sortModels.ts
+++ b/frontend/src/modeldirectory/components/modelTables/sortModels.ts
@@ -1,3 +1,6 @@
+import {SortableKeys, SortDirection} from "./withSorting.types";
+import {ModelInfoTypes} from "../../../modelInfo/modelInfoTypes";
+
 const sortItems = (aValue: any, bValue: any, key: string): number => {
   let comparison = 0;
   if (aValue instanceof Date && bValue instanceof Date) {
@@ -31,5 +34,22 @@ const sortItems = (aValue: any, bValue: any, key: string): number => {
   }
   return comparison;
 };
+export const sortModels = (models: ModelInfoTypes.ModelInfo[], sortConfig: SortConfig): ModelInfoTypes.ModelInfo[] => {
+  if (sortConfig === null) {
+    console.warn("Sorting Configuration is not set")
+    return models;
+  }
 
-export default sortItems;
+  let sortableItems = [...models]; // make a shallow copy of the array
+  return sortableItems.sort((a, b) => {
+    let comparison = sortItems(a[sortConfig.key], b[sortConfig.key], sortConfig.key)
+    return sortConfig.direction === SortDirection.ASCENDING ? comparison : -comparison;
+  });
+}
+
+export interface SortConfig {
+  key: SortableKeys;
+  direction: SortDirection;
+}
+
+export default sortModels;

--- a/frontend/src/modeldirectory/components/modelTables/withSorting.test.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/withSorting.test.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import {act, render} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import withSorting from './withSorting';
+import ModelsTable, {ModelsTableProps} from './ModelsTable';
+import {SortDirection} from "./withSorting.types";
+import {getOneFakeModel} from "./_test_utilities/mockModelData";
+import {ModelInfoTypes} from "../../../modelInfo/modelInfoTypes";
+
+// Mocking ModelsTable component
+jest.mock('./ModelsTable', () => jest.fn(() => null));
+
+
+describe('withSorting HOC', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const SortedModelsTable = withSorting(ModelsTable);
+  const givenModel= getOneFakeModel()
+
+  test('should sort models by updatedAt in descending order initially', () => {
+    // GIVEN a list of unsorted models
+    const givenUnsortedModels = [
+      { ...givenModel, id: '1', name: 'A', updatedAt: new Date('2022-01-01T00:00:00.000Z') },
+      { ...givenModel, id: '2', name: 'B', updatedAt: new Date('2022-01-02T00:00:00.000Z') }
+    ];
+
+    // WHEN the component renders
+    render(<SortedModelsTable models={givenUnsortedModels} />);
+
+    // THEN the models should be sorted by updatedAt in descending order
+    expect(ModelsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        models: [
+          { ...givenModel, id: '2', name: 'B', updatedAt: new Date('2022-01-02T00:00:00.000Z') },
+          { ...givenModel, id: '1', name: 'A', updatedAt: new Date('2022-01-01T00:00:00.000Z') }
+        ]
+      }),
+      {}
+    );
+  });
+
+  test.each([
+    // GIVEN a sorting direction of ASCENDING
+    ['ASCENDING', SortDirection.ASCENDING],
+    // GIVEN a sorting direction of DESCENDING
+    ["DESCENDING", SortDirection.DESCENDING],
+    // GIVEN no sorting direction
+    ["Not Defined", undefined]]
+  )('should sort models by name when the name is selected as a key for sorting and the direction is %s', (description : string, direction?: SortDirection) => {
+    // GIVEN a list of unsorted models
+    const givenUnsortedModels = [
+      { ...givenModel, id: '1', name: 'B' },
+      { ...givenModel, id: '2', name: 'A' }
+    ];
+
+    render(<SortedModelsTable models={givenUnsortedModels} />);
+
+    const lastCall = (ModelsTable as jest.Mock).mock.calls.pop();
+    const capturedProps = lastCall ? (lastCall[0] as ModelsTableProps) : null;
+
+    // WHEN name is selected as a key for sorting
+    act(() => {
+      capturedProps?.requestSort && capturedProps.requestSort('name', direction);
+    });
+
+    // THEN the models should be sorted by name in the defined order
+    expect(ModelsTable).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        models: givenUnsortedModels.sort((a: ModelInfoTypes.ModelInfo ,b: ModelInfoTypes.ModelInfo) => {
+          if(direction === SortDirection.DESCENDING){
+            return b.name.localeCompare(a.name)
+          }
+          return a.name.localeCompare(b.name)
+        })
+      }),
+      expect.anything()
+    );
+  });
+
+  test.each([
+    // GIVEN a sorting direction of ASCENDING
+    ['ASCENDING', SortDirection.ASCENDING],
+    // GIVEN a sorting direction of DESCENDING
+    ['DESCENDING', SortDirection.DESCENDING],
+    // GIVEN no sorting direction
+    ['Not Defined', undefined]
+  ])('should sort models by updatedAt when updatedAt is selected as a key for sorting and the direction is %s', (description : string, direction?: SortDirection) => {
+    // GIVEN a list of unsorted models
+    const givenUnsortedModels = [
+      { ...givenModel, id: '1', updatedAt: new Date('2022-01-01T00:00:00.000Z') },
+      { ...givenModel, id: '2', updatedAt: new Date('2022-01-02T00:00:00.000Z') }
+    ];
+
+    // WHEN the component renders
+    render(<SortedModelsTable models={givenUnsortedModels} />);
+
+    const lastCall = (ModelsTable as jest.Mock).mock.calls.pop();
+    const capturedProps = lastCall ? (lastCall[0] as ModelsTableProps) : null;
+
+    // WHEN updatedAt is selected as a key for sorting
+    act(() => {
+      capturedProps?.requestSort && capturedProps.requestSort('updatedAt', direction);
+    });
+
+    // THEN the models should be sorted by updatedAt in the defined order
+    expect(ModelsTable).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        models: givenUnsortedModels.sort((a: ModelInfoTypes.ModelInfo, b: ModelInfoTypes.ModelInfo) => {
+          const timeA = a.updatedAt.getTime();
+          const timeB = b.updatedAt.getTime();
+          return direction === SortDirection.ASCENDING ? timeA - timeB : timeB - timeA;
+        })
+      }),
+      expect.anything()
+    );
+  });
+
+  test.each([
+    // GIVEN a sorting direction of ASCENDING
+    ['ASCENDING', SortDirection.ASCENDING],
+    // GIVEN a sorting direction of DESCENDING
+    ['DESCENDING', SortDirection.DESCENDING],
+    // GIVEN no sorting direction
+    ['Not Defined', undefined]
+  ])('should sort models by version when version is selected as a key for sorting and the direction is %s', (description : string, direction?: SortDirection) => {
+    // GIVEN a list of unsorted models
+    const givenUnsortedModels = [
+      { ...givenModel, id: '1', version: '1.0.0' },
+      { ...givenModel, id: '2', version: '0.9.0' }
+    ];
+
+    // WHEN the component renders
+    render(<SortedModelsTable models={givenUnsortedModels} />);
+
+    const lastCall = (ModelsTable as jest.Mock).mock.calls.pop();
+    const capturedProps = lastCall ? (lastCall[0] as ModelsTableProps) : null;
+
+    // WHEN version is selected as a key for sorting
+    act(() => {
+      capturedProps?.requestSort && capturedProps.requestSort('version', direction);
+    });
+
+    // THEN the models should be sorted by version in the defined order
+    expect(ModelsTable).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        models: givenUnsortedModels.sort((a: ModelInfoTypes.ModelInfo, b: ModelInfoTypes.ModelInfo) => {
+          return direction === SortDirection.ASCENDING
+            ? a.version.localeCompare(b.version)
+            : b.version.localeCompare(a.version);
+        })
+      }),
+      expect.anything()
+    );
+  });
+
+
+  test('should handle empty models array gracefully', () => {
+    // GIVEN an empty models array
+    // WHEN the component renders
+    render(<SortedModelsTable models={[]} />);
+
+    // THEN it should render correctly without crashing
+    expect(ModelsTable).not.toThrowError();
+    expect(ModelsTable).toHaveBeenCalledWith(
+      expect.objectContaining({ models: [] }),
+      {}
+    );
+  });
+
+  test('should handle single model in models array correctly', () => {
+    // GIVEN a models array with a single model
+    const givenUnsortedModels = [{ ...givenModel, id: '1', name: 'A' }];
+
+    // WHEN the component renders
+    render(<SortedModelsTable models={givenUnsortedModels} />);
+
+    // THEN it should render correctly
+    expect(ModelsTable).toHaveBeenCalledWith(
+      expect.objectContaining({ models: givenUnsortedModels }),
+      expect.anything()
+    );
+
+    const lastCall = (ModelsTable as jest.Mock).mock.calls[0];
+    const capturedProps = lastCall ? (lastCall[0] as ModelsTableProps) : null;
+
+    // AND WHEN a sort is requested
+    act(() => {
+      capturedProps?.requestSort && capturedProps.requestSort('name');
+    });
+
+    // THEN expect the modelsTable not to get re-rendered with different props
+    expect(ModelsTable).toHaveBeenNthCalledWith(1,
+      expect.objectContaining({ models: givenUnsortedModels }),
+      expect.anything()
+    );
+  });
+});
+
+export {};

--- a/frontend/src/modeldirectory/components/modelTables/withSorting.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/withSorting.tsx
@@ -1,0 +1,47 @@
+import React, {useCallback, useMemo, useState} from 'react';
+import {ModelsTableProps} from "./ModelsTable";
+import {SortDirection, SortableKeys} from "./withSorting.types";
+
+interface SortConfig {
+  key: SortableKeys;
+  direction: SortDirection;
+}
+
+
+const withSorting = (WrappedComponent: React.FC<ModelsTableProps>) => {
+  return (props: ModelsTableProps) => {
+    const [sortConfig, setSortConfig] = useState<SortConfig>({ key: 'updatedAt', direction: SortDirection.DESCENDING });
+
+    const sortedModels = useMemo(() => {
+      let sortableItems = [...props.models];
+      if (sortConfig !== null) {
+        sortableItems.sort((a, b) => {
+          let comparison;
+
+          if (sortConfig.key === 'updatedAt') {
+            // Compare dates by converting them to timestamps
+            comparison = a.updatedAt.getTime() - b.updatedAt.getTime();
+          } else {
+            // For strings, use localeCompare for a correct comparison
+            comparison = a[sortConfig.key].localeCompare(b[sortConfig.key]);
+          }
+
+          // Determine the direction
+          return sortConfig.direction === 'ascending' ? comparison : -comparison;
+        });
+      }
+      return sortableItems;
+    }, [props.models, sortConfig]);
+
+    const requestSort = useCallback((key: SortableKeys, direction:SortDirection = key === 'name' ? SortDirection.ASCENDING : SortDirection.DESCENDING ) => {
+      if (sortConfig.key === key && sortConfig.direction === SortDirection.ASCENDING) {
+        direction = SortDirection.DESCENDING;
+      }
+      setSortConfig({ key, direction });
+    }, [sortConfig.key, sortConfig.direction]);
+
+    return <WrappedComponent {...props} models={sortedModels} requestSort={requestSort} />;
+  };
+};
+
+export default withSorting;

--- a/frontend/src/modeldirectory/components/modelTables/withSorting.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/withSorting.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {ModelsTableProps} from "./ModelsTable";
 import {SortableKeys, SortDirection} from "./withSorting.types";
 import sortItems from "./sortByHeader";
@@ -9,21 +9,22 @@ export interface SortConfig {
 }
 
 export interface SortedModelsTableProps extends ModelsTableProps {
-  sortingState?: [SortConfig, React.Dispatch<React.SetStateAction<SortConfig>>]
+  sortingState: [SortConfig, React.Dispatch<React.SetStateAction<SortConfig>>]
 }
 
 const withSorting = <P extends ModelsTableProps>(WrappedComponent: React.ComponentType<P>) => {
   return (props: P & SortedModelsTableProps) => {
-    const [sortConfig, setSortConfig] = props.sortingState ?? useState<SortConfig>({ key: 'updatedAt', direction: SortDirection.DESCENDING });
+    const [sortConfig, setSortConfig] = props.sortingState
     const sortedModels = useMemo(() => {
-      let sortableItems = [...props.models];
+      let sortableItems = [...props?.models ?? [] as ModelsTableProps['models']] as ModelsTableProps['models'];
       if (sortConfig !== null) {
         sortableItems.sort((a, b) => {
 
           let comparison = sortItems(a[sortConfig.key], b[sortConfig.key], sortConfig.key)
           return sortConfig.direction === SortDirection.ASCENDING ? comparison : -comparison;
         });
-      }
+      } else console.warn("Sorting Configuration is not set")
+
       return sortableItems;
     }, [props.models, sortConfig]);
 
@@ -39,11 +40,7 @@ const withSorting = <P extends ModelsTableProps>(WrappedComponent: React.Compone
         direction = sortConfig.direction === SortDirection.ASCENDING ? SortDirection.DESCENDING : SortDirection.ASCENDING;
       }
       setSortConfig({ key, direction });
-    }, [sortConfig.key, sortConfig.direction]);
-
-    useEffect(() => {
-      requestSort('updatedAt', SortDirection.DESCENDING)
-    }, []);
+    }, [sortConfig.key, sortConfig.direction, setSortConfig]);
 
     return <WrappedComponent {...props} models={sortedModels} requestSort={requestSort} />;
   };

--- a/frontend/src/modeldirectory/components/modelTables/withSorting.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/withSorting.tsx
@@ -1,7 +1,8 @@
 import React, {useCallback, useMemo} from 'react';
 import {ModelsTableProps} from "./ModelsTable";
 import {SortableKeys, SortDirection} from "./withSorting.types";
-import sortItems from "./sortByHeader";
+import sortItems from "./sortModels";
+import sortModels from "./sortModels";
 
 export interface SortConfig {
   key: SortableKeys;
@@ -16,16 +17,7 @@ const withSorting = <P extends ModelsTableProps>(WrappedComponent: React.Compone
   return (props: P & SortedModelsTableProps) => {
     const [sortConfig, setSortConfig] = props.sortingState
     const sortedModels = useMemo(() => {
-      let sortableItems = [...props?.models ?? [] as ModelsTableProps['models']] as ModelsTableProps['models'];
-      if (sortConfig !== null) {
-        sortableItems.sort((a, b) => {
-
-          let comparison = sortItems(a[sortConfig.key], b[sortConfig.key], sortConfig.key)
-          return sortConfig.direction === SortDirection.ASCENDING ? comparison : -comparison;
-        });
-      } else console.warn("Sorting Configuration is not set")
-
-      return sortableItems;
+      return  sortModels(props.models, sortConfig)
     }, [props.models, sortConfig]);
 
     /*
@@ -42,7 +34,7 @@ const withSorting = <P extends ModelsTableProps>(WrappedComponent: React.Compone
       setSortConfig({ key, direction });
     }, [sortConfig.key, sortConfig.direction, setSortConfig]);
 
-    return <WrappedComponent {...props} models={sortedModels} requestSort={requestSort} />;
+      return <WrappedComponent {...props} models={sortedModels} requestSort={requestSort} />;
   };
 };
 

--- a/frontend/src/modeldirectory/components/modelTables/withSorting.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/withSorting.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import {ModelsTableProps} from "./ModelsTable";
-import {SortDirection, SortableKeys} from "./withSorting.types";
+import {SortableKeys, SortDirection} from "./withSorting.types";
+import sortItems from "./sortByHeader";
 
 interface SortConfig {
   key: SortableKeys;
@@ -16,29 +17,27 @@ const withSorting = (WrappedComponent: React.FC<ModelsTableProps>) => {
       let sortableItems = [...props.models];
       if (sortConfig !== null) {
         sortableItems.sort((a, b) => {
-          let comparison;
 
-          if (sortConfig.key === 'updatedAt') {
-            // Compare dates by converting them to timestamps
-            comparison = a.updatedAt.getTime() - b.updatedAt.getTime();
-          } else {
-            // For strings, use localeCompare for a correct comparison
-            comparison = a[sortConfig.key].localeCompare(b[sortConfig.key]);
-          }
-
-          // Determine the direction
-          return sortConfig.direction === 'ascending' ? comparison : -comparison;
+          let comparison = sortItems(a[sortConfig.key], b[sortConfig.key], sortConfig.key)
+          return sortConfig.direction === SortDirection.ASCENDING ? comparison : -comparison;
         });
       }
       return sortableItems;
     }, [props.models, sortConfig]);
 
+    /*
+           If the same key is clicked, toggle the direction.
+           If a new key is clicked, use the provided direction or the default one based on the key.
+           the default for name is SortDirection.ASCENDING
+           the defaults for everything else are SortDirection.DESCENDING
+      */
     const requestSort = useCallback((key: SortableKeys, direction:SortDirection = key === 'name' ? SortDirection.ASCENDING : SortDirection.DESCENDING ) => {
       if (sortConfig.key === key && sortConfig.direction === SortDirection.ASCENDING) {
         direction = SortDirection.DESCENDING;
       }
       setSortConfig({ key, direction });
     }, [sortConfig.key, sortConfig.direction]);
+
 
     return <WrappedComponent {...props} models={sortedModels} requestSort={requestSort} />;
   };

--- a/frontend/src/modeldirectory/components/modelTables/withSorting.types.ts
+++ b/frontend/src/modeldirectory/components/modelTables/withSorting.types.ts
@@ -1,0 +1,6 @@
+export type SortableKeys = 'updatedAt' | 'name' | 'version'; // Define the keys by which sorting can be done
+
+export enum SortDirection {
+  ASCENDING = 'ascending',
+  DESCENDING = 'descending'
+}

--- a/frontend/src/modeldirectory/components/modelTables/withSorting.types.ts
+++ b/frontend/src/modeldirectory/components/modelTables/withSorting.types.ts
@@ -1,4 +1,6 @@
-export type SortableKeys = 'updatedAt' | 'name' | 'version'; // Define the keys by which sorting can be done
+import {ModelInfoTypes} from "../../../modelInfo/modelInfoTypes";
+
+export type SortableKeys = Extract<keyof ModelInfoTypes.ModelInfo, 'updatedAt' | 'name' | 'version'>; // Define the keys by which sorting can be done
 
 export enum SortDirection {
   ASCENDING = 'ascending',


### PR DESCRIPTION
- added a Higher order component that is designed to wrap the existing ModelsTable and provide sorting functionality
- currently the table doesn't quite take advantage of the sorting, but the defaults allow the model Import behaviour to be stable 