### PR TITLE
please consider the changes:

### DIFF
--- a/frontend/src/app/components/AppSidebar.tsx
+++ b/frontend/src/app/components/AppSidebar.tsx
@@ -128,7 +128,7 @@ const Container = styled(Box)`
   flex-direction: column;
   align-items: center;
   padding: 0 16px;
-  margin-top: 44px;
+  //margin-top: 44px;
   font-family: ${({ theme }) => theme.typography.fontFamily};
   height: 100%;
   padding-left: 24px;

--- a/frontend/src/modeldirectory/ModelDirectory.tsx
+++ b/frontend/src/modeldirectory/ModelDirectory.tsx
@@ -10,7 +10,21 @@ import {ModelInfoTypes} from "../modelInfo/modelInfoTypes";
 import ModelInfoService from "src/modelInfo/modelInfo.service";
 import LocaleAPISpecs from "api-specifications/locale"
 import ModelDirectoryHeader from './components/ModelDirectoryHeader/ModelDirectoryHeader';
-import { ModelDirectoryContainer } from './ModelDirectory.styles';
+import {AppBar, Box} from "@mui/material";
+import {styled} from '@mui/material/styles';
+
+ const StyledContainer = styled(Box)`
+  flex: 1;
+  overflow-y: auto;
+`;
+
+const StyledTableContainer = styled(Box)`
+  flex: 1;
+  background-color: ${({theme}) => theme.palette.background.paper};
+  border-radius: 16px 16px 0 0;
+  padding: 24px 24px 24px 24px;
+`;
+
 
 const uniqueId = "8482f1cc-0786-423f-821e-34b6b712d63f"
 export const DATA_TEST_ID = {
@@ -91,15 +105,15 @@ const ModelDirectory = () => {
     };
   }, [handleModelInfoFetch]);
 
-
   return (
-    <ModelDirectoryContainer
-      data-testid={DATA_TEST_ID.MODEL_DIRECTORY_PAGE}
-    >
-      <ModelDirectoryHeader onModalImport={() => showImportDialog(true)} />
-      <div className='model-table-container'>
-        <ModelsTable models={models} isLoading={isLoadingModels} />
-      </div>
+    <StyledContainer data-testid={DATA_TEST_ID.MODEL_DIRECTORY_PAGE}>
+      <AppBar style={{paddingBottom:"24px"}} variant={"outlined"} sx={{border:"none"}} color={"secondary"}  position={"sticky"}>
+        <ModelDirectoryHeader onModalImport={() => showImportDialog(true)}/>
+      </AppBar>
+      <StyledTableContainer>
+        <ModelsTable models={models} isLoading={isLoadingModels}/>
+      </StyledTableContainer>
+
       {isImportDlgOpen && (
         <ImportModelDialog
           isOpen={isImportDlgOpen}
@@ -113,7 +127,7 @@ const ModelDirectory = () => {
           message='The model is being created and the files uploaded. Please wait ... '
         />
       )}
-    </ModelDirectoryContainer>
+    </StyledContainer>
   );
 };
 export default ModelDirectory;

--- a/frontend/src/modeldirectory/components/ModelDirectoryHeader/ModelDirectoryHeader.tsx
+++ b/frontend/src/modeldirectory/components/ModelDirectoryHeader/ModelDirectoryHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AddIcon from '@mui/icons-material/Add';
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Button, Typography} from '@mui/material';
 import styled from '@emotion/styled';
 
 const uniqueId = '8482f1cc-0786-423f-821e-34b6b712d78u';
@@ -10,19 +10,20 @@ export const DATA_TEST_ID = {
 };
 
 interface ModelDirectoryHeaderProps {
+  style?: React.CSSProperties | undefined;
   onModalImport: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-const ImportButton = styled(Button)`
-  border-radius: 100px;
+const StyledButton = styled(Button)`
+  border-radius: 6.25rem;
 `;
 
 const ModelDirectoryHeader: React.FC<ModelDirectoryHeaderProps> = ({ onModalImport }) => (
-  <Box display='flex' width='100%' justifyContent='space-between' alignItems='center' paddingY="24px">
-    <Typography fontSize='28px' lineHeight="36px" data-testid={DATA_TEST_ID.MODEL_DIRECTORY_TITLE}>
-      Labour Taxonomies
+  <Box display='flex' width='100%' justifyContent='space-between' alignItems='center'>
+    <Typography fontSize='2rem' data-testid={DATA_TEST_ID.MODEL_DIRECTORY_TITLE}>
+      Labour Taxonomies 
     </Typography>
-    <ImportButton
+    <StyledButton
       onClick={onModalImport}
       data-testid={DATA_TEST_ID.IMPORT_MODEL_BUTTON}
       variant='contained'
@@ -31,7 +32,7 @@ const ModelDirectoryHeader: React.FC<ModelDirectoryHeaderProps> = ({ onModalImpo
       disableElevation
     >
       Import Model
-    </ImportButton>
+    </StyledButton>
   </Box>
 );
 


### PR DESCRIPTION
- ModelDirectory.tsx: use a styled div instead of the class name from the ModelDirectoryContainer
- ModelDirectory.styles.tsx: move the model-table-container style to the ModelTableContainer
- AppSidebar.tsx: remove the margin to take advantage of the limited vertical space (monitor have 16:9 ratio)
- ModelDirectoryHeader.tsx: Introduce AppBar to make the header sticky and remain in place when scrolling.