### PR TITLE
chore: import test utils from local test_utils file

### DIFF
--- a/frontend/src/app/index.test.tsx
+++ b/frontend/src/app/index.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from "@testing-library/react";
+import {render, screen} from "src/_test_utilities/test-utils";
 import TaxonomyModelApp from "./index";
 import {Route} from "react-router-dom";
 import routerConfig from "./routerConfig";

--- a/frontend/src/import/ImportModelDialog.test.tsx
+++ b/frontend/src/import/ImportModelDialog.test.tsx
@@ -1,14 +1,13 @@
 // mute the console
 import "src/_test_utilities/consoleMock";
 
-import {getByTestId, render, screen} from "src/_test_utilities/test-utils";
+import {getByTestId, render, screen, fireEvent, within} from "src/_test_utilities/test-utils";
 import ImportModelDialog, {DATA_TEST_ID, ImportData, ImportModelDialogProps} from "./ImportModelDialog";
 import {DATA_TEST_ID as MODEL_NAME_FIELD_DATA_TEST_ID} from "src/import/components/ModelNameField";
 import {DATA_TEST_ID as MODEL_LOCALE_SELECT_FIELD_DATA_TEST_ID} from "src/import/components/ModelLocalSelectField";
 import {DATA_TEST_ID as MODEL_DESCRIPTION_FIELD_DATA_TEST_ID} from "src/import/components/ModelDescriptionField";
 import {DATA_TEST_ID as IMPORT_FILE_SELECTION_DATA_TEST_ID} from "src/import/components/ImportFilesSelection";
 import {DATA_TEST_ID as FILE_ENTRY_DATA_TEST_ID} from "src/import/components/FileEntry";
-import {fireEvent, within} from "@testing-library/react";
 import ImportAPISpecs from "api-specifications/import";
 import {clickDebouncedButton, typeDebouncedInput} from "src/_test_utilities/userEventFakeTimer";
 import {ImportFiles} from "./ImportFiles.type";

--- a/frontend/src/import/components/FileEntry.test.tsx
+++ b/frontend/src/import/components/FileEntry.test.tsx
@@ -1,8 +1,7 @@
-import {fireEvent, render, screen} from "src/_test_utilities/test-utils";
+import {fireEvent, render, screen, waitFor} from "src/_test_utilities/test-utils";
 import {DATA_TEST_ID, FileEntry} from "./FileEntry";
 import ImportAPISpecs from "api-specifications/import";
 import {mapFileTypeToName} from "./mapFileTypeToName";
-import {waitFor} from "@testing-library/react";
 import {clickDebouncedButton} from "src/_test_utilities/userEventFakeTimer";
 
 describe("FileEntry render tests", () => {

--- a/frontend/src/import/components/ModelLocalSelectField.test.tsx
+++ b/frontend/src/import/components/ModelLocalSelectField.test.tsx
@@ -1,9 +1,8 @@
-import {render, screen} from "src/_test_utilities/test-utils";
+import {render, screen, within} from "src/_test_utilities/test-utils";
 import ModelLocalSelectField, {DATA_TEST_ID, TEXT} from "./ModelLocalSelectField";
 import Locale from "api-specifications/locale";
 import React from "react";
 import userEvent from "@testing-library/user-event";
-import {within} from "@testing-library/react";
 
 // Given a list of locales
 const givenLocales: Locale.Types.Payload[] = [

--- a/frontend/src/index.test.tsx
+++ b/frontend/src/index.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, within} from '@testing-library/react'
+import {render, screen, within} from '@testing-library/react' //we don't have to import from test_utils since index already have everything
 
 // mock the react-dom/client
 // Using jest.doMock() so that the render function can be accessed from within the mock

--- a/frontend/src/info/Info.test.tsx
+++ b/frontend/src/info/Info.test.tsx
@@ -6,8 +6,7 @@ import InfoService from "./info.service";
 
 import {InfoProps} from "./info.types";
 import Info, {DATA_TEST_ID} from "./Info";
-import {act, screen} from "@testing-library/react";
-import { render } from "src/_test_utilities/test-utils";
+import { render, act, screen } from "src/_test_utilities/test-utils";
 
 jest.mock("./info.service");
 

--- a/frontend/src/modeldirectory/components/ModelDirectoryHeader/ModelDirectoryHeader.test.tsx
+++ b/frontend/src/modeldirectory/components/ModelDirectoryHeader/ModelDirectoryHeader.test.tsx
@@ -1,5 +1,5 @@
 import ModelDirectoryHeader, {DATA_TEST_ID} from './ModelDirectoryHeader';
-import {render, screen} from '@testing-library/react';
+import {render, screen} from 'src/_test_utilities/test-utils';
 import userEvent from '@testing-library/user-event';
 
 describe('ModelDirectoryHeader', () => {

--- a/frontend/src/modeldirectory/components/importProcessStateIcon/ImportProcessStateIcon.test.tsx
+++ b/frontend/src/modeldirectory/components/importProcessStateIcon/ImportProcessStateIcon.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {render, screen} from "@testing-library/react";
+import {render, screen} from "src/_test_utilities/test-utils";
 import {getAllImportProcessStatePermutations} from "./_test_utilities/importProcesStateTestData";
 import ImportProcessStateIcon, {DATA_TEST_ID} from "./ImportProcessStateIcon";
 import ImportProcessStateAPISpecs from "api-specifications/importProcessState";

--- a/frontend/src/modeldirectory/components/modelTables/ModelsTable.test.tsx
+++ b/frontend/src/modeldirectory/components/modelTables/ModelsTable.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, within} from "@testing-library/react";
+import {render, screen, within} from "src/_test_utilities/test-utils";
 import ModelsTable, {CELL_MAX_LENGTH, DATA_TEST_ID, TEXT} from "./ModelsTable";
 import {
   getArrayOfFakeModels,

--- a/frontend/src/modeldirectory/components/tableLoadingRows/TableLoadingRows.test.tsx
+++ b/frontend/src/modeldirectory/components/tableLoadingRows/TableLoadingRows.test.tsx
@@ -1,5 +1,5 @@
 import { Table } from "@mui/material";
-import {render, screen} from "@testing-library/react";
+import {render, screen} from "src/_test_utilities/test-utils";
 import TableLoadingRows, {DATA_TEST_ID} from "./TableLoadingRows";
 import TableBody from "@mui/material/TableBody";
 


### PR DESCRIPTION
## What does this PR do?

Ensure that we are importing test utils (render, screen, etc..) from this file: `src/_test_utilities/test-utils`