### PR TITLE
chore(backend): Remove setting of default values when transforming cs…

### DIFF
--- a/backend/src/import/esco/ISCOGroups/ISCOGroupsParser.test.ts
+++ b/backend/src/import/esco/ISCOGroups/ISCOGroupsParser.test.ts
@@ -102,12 +102,12 @@ describe("test parseISCOGroups from", () => {
       });
       // AND all the expected rows to have been processed successfully
       expect(actualStats).toEqual({
-        rowsProcessed: 4,
+        rowsProcessed: 5,
         rowsSuccess: expectedResults.length,
-        rowsFailed: 4 - expectedResults.length,
+        rowsFailed: 5 - expectedResults.length,
       });
       // AND the non-empty import ids to have been mapped to the db id
-      expect(givenImportIdToDBIdMap.set).toHaveBeenCalledTimes(2);
+      expect(givenImportIdToDBIdMap.set).toHaveBeenCalledTimes(3);
       expectedResults
         .filter((res: Omit<INewISCOGroupSpec, "modelId">) => isSpecified(res.importId))
         .forEach((expectedSpec: Omit<INewISCOGroupSpec, "modelId">, index: number) => {

--- a/backend/src/import/esco/ISCOGroups/ISCOGroupsParser.ts
+++ b/backend/src/import/esco/ISCOGroups/ISCOGroupsParser.ts
@@ -47,14 +47,14 @@ function getRowToSpecificationTransformFn(
 ): TransformRowToSpecificationFunction<IISCOGroupRow, INewISCOGroupSpec> {
   return (row: IISCOGroupRow): INewISCOGroupSpec => {
     return {
-      ESCOUri: row.ESCOURI ?? "",
+      ESCOUri: row.ESCOURI,
       modelId: modelId,
-      originUUID: row.ORIGINUUID ?? "",
+      originUUID: row.ORIGINUUID,
       code: row.CODE,
       preferredLabel: row.PREFERREDLABEL,
       altLabels: row.ALTLABELS ? row.ALTLABELS.split("\n") : [],
-      description: row.DESCRIPTION ?? "",
-      importId: row.ID ?? "",
+      description: row.DESCRIPTION,
+      importId: row.ID,
     };
   };
 }

--- a/backend/src/import/esco/ISCOGroups/_test_data_/expected.ts
+++ b/backend/src/import/esco/ISCOGroups/_test_data_/expected.ts
@@ -19,4 +19,13 @@ export const expected: Omit<INewISCOGroupSpec, "modelId">[] = [
     description: "description\nwith\nlinebreak",
     importId: "key_2",
   },
+  {
+    ESCOUri: "",
+    originUUID: "",
+    code: "",
+    preferredLabel: "",
+    altLabels: [],
+    description: "",
+    importId: "key_3",
+  },
 ];

--- a/backend/src/import/esco/ISCOGroups/_test_data_/given.csv
+++ b/backend/src/import/esco/ISCOGroups/_test_data_/given.csv
@@ -16,3 +16,4 @@ linebreak","label1
 label2","description
 with
 linebreak"
+,key_3,,,,,

--- a/backend/src/import/esco/occupations/_test_data_/expected.ts
+++ b/backend/src/import/esco/occupations/_test_data_/expected.ts
@@ -27,4 +27,17 @@ export const expected: Omit<INewOccupationSpec, "modelId">[] = [
     regulatedProfessionNote: "regulated\nprofession\nnote\nwith\nlinebreak",
     importId: "key_2",
   },
+  {
+    ESCOUri: "",
+    originUUID: "",
+    ISCOGroupCode: "",
+    code: "",
+    preferredLabel: "",
+    altLabels: [],
+    description: "",
+    definition: "",
+    scopeNote: "",
+    regulatedProfessionNote: "",
+    importId: "key_3",
+  },
 ];

--- a/backend/src/import/esco/occupations/_test_data_/given.csv
+++ b/backend/src/import/esco/occupations/_test_data_/given.csv
@@ -25,3 +25,4 @@ profession
 note
 with
 linebreak"
+,key_3,,,,,,,,,

--- a/backend/src/import/esco/occupations/occupationsParser.test.ts
+++ b/backend/src/import/esco/occupations/occupationsParser.test.ts
@@ -102,12 +102,12 @@ describe("test parseOccupations from", () => {
       });
       // AND all the expected rows to have been processed successfully
       expect(actualStats).toEqual({
-        rowsProcessed: 4,
+        rowsProcessed: 5,
         rowsSuccess: expectedResults.length,
-        rowsFailed: 4 - expectedResults.length,
+        rowsFailed: 5 - expectedResults.length,
       });
       // AND the non-empty import ids to have been mapped to the db id
-      expect(givenImportIdToDBIdMap.set).toHaveBeenCalledTimes(2);
+      expect(givenImportIdToDBIdMap.set).toHaveBeenCalledTimes(3);
       expectedResults
         .filter((res: Omit<INewOccupationSpec, "modelId">) => isSpecified(res.importId))
         .forEach((expectedSpec: Omit<INewOccupationSpec, "modelId">, index: number) => {

--- a/backend/src/import/esco/occupations/occupationsParser.ts
+++ b/backend/src/import/esco/occupations/occupationsParser.ts
@@ -55,18 +55,18 @@ function getRowToSpecificationTransformFn(
 ): TransformRowToSpecificationFunction<IOccupationRow, INewOccupationSpec> {
   return (row: IOccupationRow) => {
     return {
-      ESCOUri: row.ESCOURI ?? "",
+      ESCOUri: row.ESCOURI,
       modelId: modelId,
-      originUUID: row.ORIGINUUID ?? "",
+      originUUID: row.ORIGINUUID,
       ISCOGroupCode: row.ISCOGROUPCODE,
       code: row.CODE,
       preferredLabel: row.PREFERREDLABEL,
       altLabels: row.ALTLABELS ? row.ALTLABELS.split("\n") : [],
-      description: row.DESCRIPTION ?? "",
-      definition: row.DEFINITION ?? "",
-      scopeNote: row.SCOPENOTE ?? "",
-      regulatedProfessionNote: row.REGULATEDPROFESSIONNOTE ?? "",
-      importId: row.ID ?? "",
+      description: row.DESCRIPTION,
+      definition: row.DEFINITION,
+      scopeNote: row.SCOPENOTE,
+      regulatedProfessionNote: row.REGULATEDPROFESSIONNOTE,
+      importId: row.ID,
     };
   };
 }

--- a/backend/src/import/esco/skillGroups/_test_data_/expected.ts
+++ b/backend/src/import/esco/skillGroups/_test_data_/expected.ts
@@ -21,4 +21,14 @@ export const expected: Omit<INewSkillGroupSpec, "modelId">[] = [
     scopeNote: "scopeNote\nwith\nlinebreak",
     importId: "key_2",
   },
+  {
+    ESCOUri: "",
+    originUUID: "",
+    code: "",
+    preferredLabel: "",
+    altLabels: [],
+    description: "",
+    scopeNote: "",
+    importId: "key_3",
+  },
 ];

--- a/backend/src/import/esco/skillGroups/_test_data_/given.csv
+++ b/backend/src/import/esco/skillGroups/_test_data_/given.csv
@@ -18,3 +18,4 @@ with
 linebreak","scopeNote
 with
 linebreak"
+,key_3,,,,,,

--- a/backend/src/import/esco/skillGroups/skillGroupsParser.test.ts
+++ b/backend/src/import/esco/skillGroups/skillGroupsParser.test.ts
@@ -103,12 +103,12 @@ describe("test parseSkillGroups from", () => {
       });
       // AND all the expected rows to have been processed successfully
       expect(actualStats).toEqual({
-        rowsProcessed: 4,
+        rowsProcessed: 5,
         rowsSuccess: expectedResults.length,
-        rowsFailed: 4 - expectedResults.length,
+        rowsFailed: 5 - expectedResults.length,
       });
       // AND the non-empty import ids to have been mapped to the db id
-      expect(givenImportIdToDBIdMap.set).toHaveBeenCalledTimes(2);
+      expect(givenImportIdToDBIdMap.set).toHaveBeenCalledTimes(3);
 
       expectedResults
         .filter((res: Omit<INewSkillGroupSpec, "modelId">) => isSpecified(res.importId))

--- a/backend/src/import/esco/skillGroups/skillGroupsParser.ts
+++ b/backend/src/import/esco/skillGroups/skillGroupsParser.ts
@@ -49,15 +49,15 @@ function getRowToSpecificationTransformFn(
 ): TransformRowToSpecificationFunction<ISkillGroupRow, INewSkillGroupSpec> {
   return (row: ISkillGroupRow) => {
     return {
-      ESCOUri: row.ESCOURI ?? "",
+      ESCOUri: row.ESCOURI,
       modelId: modelId,
-      originUUID: row.ORIGINUUID ?? "",
-      code: row.CODE ?? "",
+      originUUID: row.ORIGINUUID,
+      code: row.CODE,
       preferredLabel: row.PREFERREDLABEL,
       altLabels: row.ALTLABELS ? row.ALTLABELS.split("\n") : [],
-      description: row.DESCRIPTION ?? "",
-      scopeNote: row.SCOPENOTE ?? "",
-      importId: row.ID ?? "",
+      description: row.DESCRIPTION,
+      scopeNote: row.SCOPENOTE,
+      importId: row.ID,
     };
   };
 }

--- a/backend/src/import/esco/skills/_test_data_/expected.ts
+++ b/backend/src/import/esco/skills/_test_data_/expected.ts
@@ -25,4 +25,16 @@ export const expected: Omit<INewSkillSpec, "modelId">[] = [
     reuseLevel: "cross-sector",
     importId: "key_2",
   },
+  {
+    ESCOUri: "",
+    originUUID: "",
+    preferredLabel: "",
+    altLabels: [],
+    description: "",
+    definition: "",
+    scopeNote: "",
+    skillType: "",
+    reuseLevel: "",
+    importId: "key_3",
+  },
 ];

--- a/backend/src/import/esco/skills/_test_data_/given.csv
+++ b/backend/src/import/esco/skills/_test_data_/given.csv
@@ -20,3 +20,4 @@ with
 linebreak",knowledge,cross-sector,"scopeNote
 with
 linebreak"
+,key_3,,,,,,,,

--- a/backend/src/import/esco/skills/skillsParser.test.ts
+++ b/backend/src/import/esco/skills/skillsParser.test.ts
@@ -101,12 +101,12 @@ describe("test parseSkills from", () => {
       });
       // AND all the expected rows to have been processed successfully
       expect(actualStats).toEqual({
-        rowsProcessed: 4,
+        rowsProcessed: 5,
         rowsSuccess: expectedResults.length,
-        rowsFailed: 4 - expectedResults.length,
+        rowsFailed: 5 - expectedResults.length,
       });
       // AND the non-empty import ids to have been mapped to the db id
-      expect(givenImportIdToDBIdMap.set).toHaveBeenCalledTimes(2);
+      expect(givenImportIdToDBIdMap.set).toHaveBeenCalledTimes(3);
       expectedResults
         .filter((res: Omit<INewSkillSpec, "modelId">) => isSpecified(res.importId))
         .forEach((expectedSpec: Omit<INewSkillSpec, "modelId">, index: number) => {

--- a/backend/src/import/esco/skills/skillsParser.ts
+++ b/backend/src/import/esco/skills/skillsParser.ts
@@ -54,17 +54,17 @@ function getRowToSpecificationTransformFn(
   return (row: ISkillRow) => {
     // @ts-ignore
     return {
-      ESCOUri: row.ESCOURI ?? "",
+      ESCOUri: row.ESCOURI,
       modelId: modelId,
-      originUUID: row.ORIGINUUID ?? "",
+      originUUID: row.ORIGINUUID,
       preferredLabel: row.PREFERREDLABEL,
       altLabels: row.ALTLABELS ? row.ALTLABELS.split("\n") : [],
-      description: row.DESCRIPTION ?? "",
-      definition: row.DEFINITION ?? "",
-      scopeNote: row.SCOPENOTE ?? "",
-      reuseLevel: (row.REUSELEVEL as ReuseLevel) ?? "",
-      skillType: (row.SKILLTYPE as SkillType) ?? "",
-      importId: row.ID ?? "",
+      description: row.DESCRIPTION,
+      definition: row.DEFINITION,
+      scopeNote: row.SCOPENOTE,
+      reuseLevel: row.REUSELEVEL as ReuseLevel,
+      skillType: row.SKILLTYPE as SkillType,
+      importId: row.ID,
     };
   };
 }


### PR DESCRIPTION
…v rows. The conditions are never reached because the row cannot have undefined values, the parser will fail at an earlier step while the file is parsed.