### PR TITLE
chore: upgrade mongoose version for better db connection error handling

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,22 +23,23 @@
     "format": "prettier --write src/ *.js"
   },
   "devDependencies": {
-    "@aws-sdk/s3-presigned-post": "^3.328.0",
     "@aws-sdk/client-lambda": "~3.338.0",
+    "@aws-sdk/s3-presigned-post": "^3.328.0",
     "@aws-sdk/s3-request-presigner": "^3.338.0",
+    "@redocly/cli": "~1.0.2",
+    "@shelf/jest-mongodb": "~4.1.7",
     "@types/aws-lambda": "~8.10.114",
     "@types/jest": "~29.5.0",
     "@types/mongodb": "^4.0.7",
     "@types/mongoose": "^5.11.97",
     "@types/supertest": "~2.0.12",
-    "@shelf/jest-mongodb": "~4.1.7",
     "@types/swagger-jsdoc": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.31.0",
-    "@redocly/cli": "~1.0.2",
     "esbuild": "~0.17.17",
     "eslint": "^8.40.0",
     "eslint-config-prettier": "^9.0.0",
+    "http-server": "~14.1.1",
     "jest": "~29.5.0",
     "jest-performance-matchers": "~1.0.0",
     "prettier": "^3.0.3",
@@ -49,14 +50,13 @@
     "swagger-jsdoc": "~6.2.8",
     "ts-jest": "~29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "~4.4.2",
-    "http-server": "~14.1.1"
+    "typescript": "~4.4.2"
   },
   "dependencies": {
     "ajv": "^8.12.0",
     "ajv-formats": "~2.1.1",
     "aws-sdk": "^2.1368.0",
-    "mongoose": "^7.1.0",
-    "csv-parse": "~5.4.0"
+    "csv-parse": "~5.4.0",
+    "mongoose": "^7.6.3"
   }
 }

--- a/backend/src/_test_utilities/testDBConnectionFaillure.ts
+++ b/backend/src/_test_utilities/testDBConnectionFaillure.ts
@@ -1,0 +1,38 @@
+import { getTestConfiguration } from "./getTestConfiguration";
+import { getNewConnection } from "server/connection/newConnection";
+import { RepositoryRegistry } from "server/repositoryRegistry/repositoryRegistry";
+
+export function TestDBConnectionFailure<S, A>(
+  setupCallback: (repositoryRegistry: RepositoryRegistry) => Promise<S> | S,
+  actionCallback: (setupResult: S, repositoryRegistry: RepositoryRegistry) => Promise<A>
+) {
+  return test("should reject with an error when connection to database is lost", async () => {
+    // GIVEN the db connection will be lost
+    const givenConfig = getTestConfiguration("ConnectionFailureTestDB");
+    const givenConnection = await getNewConnection(givenConfig.dbURI);
+    const givenRepositoryRegistry = new RepositoryRegistry();
+    await givenRepositoryRegistry.initialize(givenConnection);
+
+    // AND the setup is done
+    const setupResult = await setupCallback(givenRepositoryRegistry);
+    // AND the connection is lost
+    await givenConnection.close(false);
+
+    // WHEN expect action is called
+    const actualActionPromise = actionCallback(setupResult, givenRepositoryRegistry);
+
+    // THEN expected it to reject with an error
+    await expect(actualActionPromise).rejects.toThrowError(/Client must be connected before running operations/);
+  });
+}
+
+export function TestDBConnectionFailureNoSetup<A>(
+  actionCallback: (repositoryRegistry: RepositoryRegistry) => Promise<A>
+) {
+  return TestDBConnectionFailure<void, A>(
+    () => {
+      return;
+    },
+    (_, repositoryRegistry) => actionCallback(repositoryRegistry)
+  );
+}

--- a/backend/src/esco/iscoGroup/ISCOGroupRepository.ts
+++ b/backend/src/esco/iscoGroup/ISCOGroupRepository.ts
@@ -155,10 +155,10 @@ export class ISCOGroupRepository implements IISCOGroupRepository {
           },
         })
         .exec();
-      return iscoGroup != null ? iscoGroup.toObject() : null;
+      return iscoGroup ? iscoGroup.toObject() : null;
     } catch (e: unknown) {
       console.error("findById failed", e);
-      return null;
+      throw e;
     }
   }
 }

--- a/backend/src/esco/occupation/OccupationRepository.ts
+++ b/backend/src/esco/occupation/OccupationRepository.ts
@@ -23,6 +23,12 @@ export interface IOccupationRepository {
    */
   createMany(newOccupationSpecs: INewOccupationSpec[]): Promise<IOccupation[]>;
 
+  /**
+   * Finds an Occupation entry by its ID.
+   *
+   * @param {string} id - The unique ID of the Occupation entry.
+   * @return {Promise<IOccupation|null>} Resolves to the Occupation entry if found, or null if not found. Rejects with an error on failure.
+   */
   findById(id: string): Promise<IOccupation | null>;
 }
 
@@ -154,7 +160,7 @@ export class OccupationRepository implements IOccupationRepository {
       return occupation != null ? occupation.toObject() : null;
     } catch (e: unknown) {
       console.error("findById failed", e);
-      return null;
+      throw e;
     }
   }
 }

--- a/backend/src/esco/occupationHierarchy/occupationHierarchyRepository.ts
+++ b/backend/src/esco/occupationHierarchy/occupationHierarchyRepository.ts
@@ -40,23 +40,25 @@ export class OccupationHierarchyRepository implements IOccupationHierarchyReposi
     newOccupationHierarchyPairSpecs: INewOccupationHierarchyPairSpec[]
   ): Promise<IOccupationHierarchyPair[]> {
     if (!mongoose.Types.ObjectId.isValid(modelId)) throw new Error(`Invalid modelId: ${modelId}`);
-    const existingIds = new Map<string, ObjectTypes>();
-
-    //  get all ISCO groups
-    const _existingIscoGroupIds = await this.iscoGroupModel
-      .find({ modelId: { $eq: modelId } })
-      .select("_id")
-      .exec();
-    _existingIscoGroupIds.forEach((iscoGroup) => existingIds.set(iscoGroup._id.toString(), ObjectTypes.ISCOGroup));
-
-    //  get all Occupations
-    const _existingOccupationsIds = await this.occupationModel
-      .find({ modelId: { $eq: modelId } })
-      .select("_id")
-      .exec();
-    _existingOccupationsIds.forEach((occupation) => existingIds.set(occupation._id.toString(), ObjectTypes.Occupation));
-
     try {
+      const existingIds = new Map<string, ObjectTypes>();
+
+      //  get all ISCO groups
+      const _existingIscoGroupIds = await this.iscoGroupModel
+        .find({ modelId: { $eq: modelId } })
+        .select("_id")
+        .exec();
+      _existingIscoGroupIds.forEach((iscoGroup) => existingIds.set(iscoGroup._id.toString(), ObjectTypes.ISCOGroup));
+
+      //  get all Occupations
+      const _existingOccupationsIds = await this.occupationModel
+        .find({ modelId: { $eq: modelId } })
+        .select("_id")
+        .exec();
+      _existingOccupationsIds.forEach((occupation) =>
+        existingIds.set(occupation._id.toString(), ObjectTypes.Occupation)
+      );
+
       const newOccupationHierarchyPairModels = newOccupationHierarchyPairSpecs
         .filter((spec) => {
           return isHierarchyPairValid(spec, existingIds, [

--- a/backend/src/esco/skill/SkillRepository.ts
+++ b/backend/src/esco/skill/SkillRepository.ts
@@ -1,11 +1,11 @@
 import mongoose from "mongoose";
 import { randomUUID } from "crypto";
 import { INewSkillSpec, ISkill, ISkillDoc, ISkillReferenceDoc } from "./skills.types";
-import { ReferenceWithModelId } from "../common/objectTypes";
-import { MongooseModelName } from "../common/mongooseModelNames";
+import { ReferenceWithModelId } from "esco/common/objectTypes";
+import { MongooseModelName } from "esco/common/mongooseModelNames";
 import { getSkillReferenceWithModelId } from "./skillReference";
-import { getSkillGroupReferenceWithModelId } from "../skillGroup/skillGroupReference";
-import { ISkillGroupReferenceDoc } from "../skillGroup/skillGroup.types";
+import { getSkillGroupReferenceWithModelId } from "esco/skillGroup/skillGroupReference";
+import { ISkillGroupReferenceDoc } from "esco/skillGroup/skillGroup.types";
 
 export interface ISkillRepository {
   readonly Model: mongoose.Model<ISkillDoc>;
@@ -158,7 +158,6 @@ export class SkillRepository implements ISkillRepository {
           },
         })
         .exec();
-
       return skill ? skill.toObject() : null;
     } catch (e: unknown) {
       console.error("findById failed", e);

--- a/backend/src/esco/skill/skills.types.ts
+++ b/backend/src/esco/skill/skills.types.ts
@@ -1,6 +1,6 @@
 import mongoose from "mongoose";
 import { ImportIdentifiable, ObjectTypes } from "esco/common/objectTypes";
-import { ISkillGroupReference } from "../skillGroup/skillGroup.types";
+import { ISkillGroupReference } from "esco/skillGroup/skillGroup.types";
 
 export type SkillType = "" | "skill/competence" | "knowledge" | "language" | "attitude";
 export type ReuseLevel = "" | "sector-specific" | "occupation-specific" | "cross-sector" | "transversal";

--- a/backend/src/esco/skillGroup/SkillGroupRepository.ts
+++ b/backend/src/esco/skillGroup/SkillGroupRepository.ts
@@ -156,11 +156,10 @@ export class SkillGroupRepository implements ISkillGroupRepository {
           },
         })
         .exec();
-
       return skillGroup != null ? skillGroup.toObject() : null;
     } catch (e: unknown) {
       console.error("findById failed", e);
-      return null;
+      throw e;
     }
   }
 }

--- a/backend/src/esco/skillGroup/skillGroup.types.ts
+++ b/backend/src/esco/skillGroup/skillGroup.types.ts
@@ -1,6 +1,6 @@
 import { ImportIdentifiable, ObjectTypes } from "esco/common/objectTypes";
 import mongoose from "mongoose";
-import { ISkillReference } from "../skill/skills.types";
+import { ISkillReference } from "esco/skill/skills.types";
 
 export interface ISkillGroupDoc extends ImportIdentifiable {
   id: string | mongoose.Types.ObjectId;

--- a/backend/src/esco/skillGroup/skillGroupModel.ts
+++ b/backend/src/esco/skillGroup/skillGroupModel.ts
@@ -11,7 +11,7 @@ import {
 } from "esco/common/modelSchema";
 import { ISkillGroupDoc } from "./skillGroup.types";
 import { MongooseModelName } from "esco/common/mongooseModelNames";
-import { stringRequired } from "../../server/stringRequired";
+import { stringRequired } from "server/stringRequired";
 
 export function initializeSchemaAndModel(dbConnection: mongoose.Connection): mongoose.Model<ISkillGroupDoc> {
   // Main Schema

--- a/backend/src/esco/skillHierarchy/skillHierarchyRepository.ts
+++ b/backend/src/esco/skillHierarchy/skillHierarchyRepository.ts
@@ -34,22 +34,23 @@ export class SkillHierarchyRepository implements ISkillHierarchyRepository {
   ): Promise<ISkillHierarchyPair[]> {
     if (!mongoose.Types.ObjectId.isValid(modelId)) throw new Error(`Invalid modelId: ${modelId}`);
     const existingIds = new Map<string, ObjectTypes>();
-
-    // Get all SkillGroups
-    const _existingSkillGroupIds = await this.skillGroupModel
-      .find({ modelId: { $eq: modelId } })
-      .select("_id")
-      .exec();
-    _existingSkillGroupIds.forEach((skillGroup) => existingIds.set(skillGroup._id.toString(), ObjectTypes.SkillGroup));
-
-    // Get all Skills
-    const _existingSkillsIds = await this.skillModel
-      .find({ modelId: { $eq: modelId } })
-      .select("_id")
-      .exec();
-    _existingSkillsIds.forEach((skill) => existingIds.set(skill._id.toString(), ObjectTypes.Skill));
-
     try {
+      // Get all SkillGroups
+      const _existingSkillGroupIds = await this.skillGroupModel
+        .find({ modelId: { $eq: modelId } })
+        .select("_id")
+        .exec();
+      _existingSkillGroupIds.forEach((skillGroup) =>
+        existingIds.set(skillGroup._id.toString(), ObjectTypes.SkillGroup)
+      );
+
+      // Get all Skills
+      const _existingSkillsIds = await this.skillModel
+        .find({ modelId: { $eq: modelId } })
+        .select("_id")
+        .exec();
+      _existingSkillsIds.forEach((skill) => existingIds.set(skill._id.toString(), ObjectTypes.Skill));
+
       const newSkillHierarchyPairModels = newSkillHierarchyPairSpecs
         .filter((spec) => {
           return isHierarchyPairValid(spec, existingIds, [

--- a/backend/src/modelInfo/modelInfoModel.test.ts
+++ b/backend/src/modelInfo/modelInfoModel.test.ts
@@ -2,7 +2,7 @@
 import "_test_utilities/consoleMock";
 
 import mongoose, { Connection } from "mongoose";
-import { ModelName, initializeSchemaAndModel } from "./modelInfoModel";
+import { initializeSchemaAndModel } from "./modelInfoModel";
 import ModelInfoAPISpecs from "api-specifications/modelInfo";
 import LocaleAPISpecs from "api-specifications/locale";
 import { randomUUID } from "crypto";
@@ -22,8 +22,7 @@ describe("Test the definition of the ModelInfo Model", () => {
     const config = getTestConfiguration("ModelInfoModelTestDB");
     dbConnection = await getNewConnection(config.dbURI);
     // Initializing the schema and model
-    initializeSchemaAndModel(dbConnection);
-    ModelInfoModel = dbConnection.model(ModelName);
+    ModelInfoModel = initializeSchemaAndModel(dbConnection);
   });
 
   afterAll(async () => {

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -3189,6 +3189,13 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
+"@mongodb-js/saslprep@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz#022fa36620a7287d17acd05c4aae1e5f390d250d"
+  integrity sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==
+  dependencies:
+    sparse-bitfield "^3.0.3"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -3930,6 +3937,11 @@ bson@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/bson/-/bson-5.3.0.tgz#37b006df4cd91ed125cb686467c1dd6d4606b514"
   integrity sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag==
+
+bson@^5.5.0:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-5.5.1.tgz#f5849d405711a7f23acdda9a442375df858e6833"
+  integrity sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==
 
 buffer-crc32@~0.2.3:
   version "0.2.13"
@@ -5869,6 +5881,17 @@ mongodb@5.3.0:
   optionalDependencies:
     saslprep "^1.0.3"
 
+mongodb@5.9.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-5.9.0.tgz#5a22065fa8cfaf1d58bf2e3c451cd2c4bfa983a2"
+  integrity sha512-g+GCMHN1CoRUA+wb1Agv0TI4YTSiWr42B5ulkiAfLLHitGK1R+PkSAf3Lr5rPZwi/3F04LiaZEW0Kxro9Fi2TA==
+  dependencies:
+    bson "^5.5.0"
+    mongodb-connection-string-url "^2.6.0"
+    socks "^2.7.1"
+  optionalDependencies:
+    "@mongodb-js/saslprep" "^1.1.0"
+
 mongodb@^4.13.0:
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.16.0.tgz#8b0043de7b577c6a7e0ce44a2ca7315b9c0a7927"
@@ -5881,7 +5904,7 @@ mongodb@^4.13.0:
     "@aws-sdk/credential-providers" "^3.186.0"
     saslprep "^1.0.3"
 
-mongoose@*, mongoose@^7.1.0:
+mongoose@*:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-7.1.1.tgz#a0e17be54754dd8801cb3696585b949399550aa9"
   integrity sha512-AIxaWwGY+td7QOMk4NgK6fbRuGovFyDzv65nU1uj1DsUh3lpjfP3iFYHSR+sUKrs7nbp19ksLlRXkmInBteSCA==
@@ -5889,6 +5912,19 @@ mongoose@*, mongoose@^7.1.0:
     bson "^5.2.0"
     kareem "2.5.1"
     mongodb "5.3.0"
+    mpath "0.9.0"
+    mquery "5.0.0"
+    ms "2.1.3"
+    sift "16.0.1"
+
+mongoose@^7.6.3:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-7.6.3.tgz#b06507dd164ad4426013eeb266d54aa1e5178092"
+  integrity sha512-moYP2qWCOdWRDeBxqB/zYwQmQnTBsF5DoolX5uPyI218BkiA1ujGY27P0NTd4oWIX+LLkZPw0LDzlc/7oh1plg==
+  dependencies:
+    bson "^5.5.0"
+    kareem "2.5.1"
+    mongodb "5.9.0"
     mpath "0.9.0"
     mquery "5.0.0"
     ms "2.1.3"


### PR DESCRIPTION
Testing connection failure with the insetMany() was not possible, as force closing the connection would throw an uncaught exception instead of the operation rejecting. This was a bug in the mongoose 7.1 version that was resolved to a later update.