### PR TITLE
wip: added handleInsertManyErrors function to generalize repository errors

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,6 +2,7 @@
 const { compilerOptions } = require("./tsconfig.json");
 const mongodbPreset = require("@shelf/jest-mongodb/jest-preset");
 module.exports = {
+  setupFilesAfterEnv: ["jest-extended/all"],
   preset: "@shelf/jest-mongodb",
   testPathIgnorePatterns: ["<rootDir>/build", "<rootDir>/coverage", "<rootDir>/deploy", "<rootDir>/test"],
   modulePathIgnorePatterns: ["<rootDir>/build"],

--- a/backend/package.json
+++ b/backend/package.json
@@ -41,6 +41,7 @@
     "eslint-config-prettier": "^9.0.0",
     "http-server": "~14.1.1",
     "jest": "~29.5.0",
+    "jest-extended": "~4.0.2",
     "jest-performance-matchers": "~1.0.0",
     "prettier": "^3.0.3",
     "rimraf": "~3.0.2",

--- a/backend/src/esco/common/handlInsertManyErrors.test.ts
+++ b/backend/src/esco/common/handlInsertManyErrors.test.ts
@@ -1,0 +1,107 @@
+//mute chatty console
+import "_test_utilities/consoleMock";
+
+import { handleInsertManyError } from "./handleInsertManyErrors";
+
+import mongoose, { mongo } from "mongoose";
+
+function getMockDocument() {
+  const id = new mongoose.Types.ObjectId();
+  return {
+    id,
+    populate: jest.fn(),
+    toObject: jest.fn().mockReturnValue({ id }),
+  };
+}
+
+describe("handleInsertManyError", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should handle MongoBulkWriteError with multiple populations", async () => {
+    // GIVEN a MongoBulkWriteError with N inserted documents
+    const givenInsertedDocuments = Array.from({ length: 3 }, () => getMockDocument());
+    const givenError = new mongoose.mongo.MongoBulkWriteError(new Error("Some error"), {} as mongo.BulkWriteResult);
+    givenError.insertedDocs = givenInsertedDocuments;
+    // AND some populate options
+    const givenPopulateOptions: mongoose.PopulateOptions[] = [{ path: "populatedField1" }, { path: "populatedField2" }];
+    // AND some expected caller info
+    const givenCallerInfo = "someCallerInfo";
+    // AND some expected count
+    const givenExpectedCount = 10;
+
+    // WHEN handleInsertManyError is called with the given error, callerInfo, expected count and populate options
+    const actualResult: { name: string }[] = await handleInsertManyError(
+      givenError,
+      givenCallerInfo,
+      givenExpectedCount,
+      givenPopulateOptions
+    );
+
+    // THEN it should return the inserted document transformed by toObject()
+    expect(actualResult).toHaveLength(givenInsertedDocuments.length);
+    expect(actualResult).toEqual(expect.arrayContaining(givenInsertedDocuments.map((doc) => doc.toObject())));
+
+    // AND it should have called the populate() method of each documents with the given populate options before calling toObject()
+    for (const mockDoc of givenInsertedDocuments) {
+      expect(mockDoc.populate).toHaveBeenCalledWith(givenPopulateOptions);
+      expect(mockDoc.populate).toHaveBeenCalledBefore(mockDoc.toObject);
+    }
+
+    // AND it should have logged a warning
+    expect(console.warn).toHaveBeenCalledWith(
+      `${givenCallerInfo}: ${givenInsertedDocuments.length} out of ${givenExpectedCount} documents were inserted successfully.`
+    );
+  });
+
+  test("should handle MongoBulkWriteError without population", async () => {
+    // GIVEN a MongoBulkWriteError with N inserted document
+    const givenInsertedDocuments = Array.from({ length: 3 }, () => getMockDocument());
+    const givenError = new mongoose.mongo.MongoBulkWriteError(new Error("Some error"), {} as mongo.BulkWriteResult);
+    givenError.insertedDocs = givenInsertedDocuments;
+    // AND some expected caller info
+    const givenCallerInfo = "someCallerInfo";
+    // AND some expected count
+    const givenExpectedCount = 10;
+    // WHEN handleInsertManyError is called with the given error, callerInfo, expected count
+    const actualResult: { name: string }[] = await handleInsertManyError(
+      givenError,
+      givenCallerInfo,
+      givenExpectedCount
+    );
+
+    // THEN it should return the inserted document transformed by toObject()
+    expect(actualResult).toHaveLength(givenInsertedDocuments.length);
+    expect(actualResult).toEqual(expect.arrayContaining(givenInsertedDocuments.map((doc) => doc.toObject())));
+
+    // AND it should have called the populate() method of each documents with the given populate options before calling toObject()
+    for (const mockDoc of givenInsertedDocuments) {
+      expect(mockDoc.populate).not.toHaveBeenCalled();
+    }
+
+    // AND it should have logged a warning
+    expect(console.warn).toHaveBeenCalledWith(
+      `${givenCallerInfo}: ${givenInsertedDocuments.length} out of ${givenExpectedCount} documents were inserted successfully.`
+    );
+  });
+
+  test("should throw error for non-bulk write errors", async () => {
+    // GIVEN a non-bulk write error
+    const givenError = new Error("Some error");
+    // AND some expected caller info
+    const givenCallerInfo = "someCallerInfo";
+    // AND some expected count
+    const givenExpectedCount = 10;
+    // WHEN handleInsertManyError is called with the error
+    const actualPromise = handleInsertManyError(givenError, givenCallerInfo, givenExpectedCount);
+
+    // THEN it should throw the error
+    await expect(actualPromise).rejects.toThrow(givenError);
+    // AND it should have logged a warning
+    expect(console.error).toHaveBeenCalledWith(
+      `${givenCallerInfo}: none of the ${givenExpectedCount} documents were inserted.`,
+      givenError
+    );
+  });
+});

--- a/backend/src/esco/common/handleInsertManyErrors.ts
+++ b/backend/src/esco/common/handleInsertManyErrors.ts
@@ -1,0 +1,27 @@
+import mongoose from "mongoose";
+
+export async function handleInsertManyError<T>(
+  error: unknown,
+  callerInfo: string,
+  expectedCount: number,
+  populateOptions?: mongoose.PopulateOptions[] | mongoose.PopulateOptions
+): Promise<T[]> {
+  // If the error is a bulk write error, we can still return the inserted documents
+  // Such an error will occur if a unique index is violated
+  if ((error as { name?: string }).name === "MongoBulkWriteError") {
+    const bulkWriteError = error as mongoose.mongo.MongoBulkWriteError;
+    console.warn(
+      `${callerInfo}: ${bulkWriteError.insertedDocs.length} out of ${expectedCount} documents were inserted successfully.`
+    );
+    const insertedDocuments: T[] = [];
+    for await (const doc of bulkWriteError.insertedDocs) {
+      if (populateOptions) {
+        await doc.populate(populateOptions);
+      }
+      insertedDocuments.push(doc.toObject() as T);
+    }
+    return insertedDocuments;
+  }
+  console.error(`${callerInfo}: none of the ${expectedCount} documents were inserted.`, error);
+  throw error;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -14,6 +14,7 @@
     "outDir": "build",
     "baseUrl": "src"
   },
+  "files": ["node_modules/jest-extended/types/index.d.ts"],
   "include": [
     "src/**/*.ts",
     "test/**/*.ts"

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -3072,6 +3072,13 @@
   dependencies:
     "@sinclair/typebox" "^0.25.16"
 
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
+
 "@jest/source-map@^29.4.3":
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-29.4.3.tgz#ff8d05cbfff875d4a791ab679b4333df47951d20"
@@ -3277,6 +3284,11 @@
   version "0.25.24"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
   integrity sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==
+
+"@sinclair/typebox@^0.27.8":
+  version "0.27.8"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
+  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
 "@sinonjs/commons@^2.0.0":
   version "2.0.0"
@@ -4278,6 +4290,11 @@ diff-sequences@^29.4.3:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.4.3.tgz#9314bc1fabe09267ffeca9cbafc457d8499a13f2"
   integrity sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==
 
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -5233,6 +5250,16 @@ jest-config@^29.5.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
+jest-diff@^29.0.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
 jest-diff@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.5.0.tgz#e0d83a58eb5451dcc1fa61b1c3ee4e8f5a290d63"
@@ -5272,6 +5299,19 @@ jest-environment-node@^29.5.0:
     "@types/node" "*"
     jest-mock "^29.5.0"
     jest-util "^29.5.0"
+
+jest-extended@~4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/jest-extended/-/jest-extended-4.0.2.tgz#d23b52e687cedf66694e6b2d77f65e211e99e021"
+  integrity sha512-FH7aaPgtGYHc9mRjriS0ZEHYM5/W69tLrFTIdzm+yJgeoCmmrSB/luSfMSqWP9O29QWHPEmJ4qmU6EwsZideog==
+  dependencies:
+    jest-diff "^29.0.0"
+    jest-get-type "^29.0.0"
+
+jest-get-type@^29.0.0, jest-get-type@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
+  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
 
 jest-get-type@^29.4.3:
   version "29.4.3"
@@ -6266,6 +6306,15 @@ pretty-format@^29.0.0, pretty-format@^29.5.0:
   integrity sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==
   dependencies:
     "@jest/schemas" "^29.4.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 


### PR DESCRIPTION
- [x]  unit tests fot handleInsertManyErrors.ts
- [x] prettier --write
- [ ] The unique index i.e. duplicate tests should be adjusted as they are the ones to provoke a MongoBuldWirteError