### PR TITLE
chore(api-specs): add dist to the modulePathIgnorePatterns

### DIFF
--- a/api-specifications/jest.config.js
+++ b/api-specifications/jest.config.js
@@ -1,12 +1,11 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 const {compilerOptions} = require('./tsconfig.json')
 module.exports = {
-
   testPathIgnorePatterns: [
     "<rootDir>/dist",
     "<rootDir>/coverage",
   ],
-  modulePathIgnorePatterns: ["<rootDir>/build"],
+  modulePathIgnorePatterns: ["<rootDir>/build", "<rootDir>/dist"],
   moduleDirectories: ["node_modules", "<rootDir>/src"],
   transform: { // override default transform to use a custom inline tsconfig
     // process js/ts with `ts-jest`


### PR DESCRIPTION
 in order to avoid jest conflicts especially with respect to package.json