### PR TITLE
fix(backend): fix the update exportProcessState repository's method 

### DIFF
--- a/backend/src/export/exportProcessState/exportProcessStateRepository.ts
+++ b/backend/src/export/exportProcessState/exportProcessStateRepository.ts
@@ -60,12 +60,24 @@ export class ExportProcessStateRepository implements IExportProcessStateReposito
 
   async update(id: string, updateSpecs: IUpdateExportProcessStateSpec): Promise<IExportProcessState> {
     try {
-      const updateResult = await this.Model.updateOne({ _id: id }, updateSpecs).exec();
-      if (!updateResult.modifiedCount) {
+      const doc = await this.Model.findById(id).exec();
+      if (doc === null) {
         throw new Error("Update failed to find export process with id: " + id);
       }
-      const exportProcessState = (await this.Model.findById(id)) as mongoose.Document<IExportProcessStateDoc>;
-      return exportProcessState.toObject();
+      if (updateSpecs.status) {
+        doc.status = updateSpecs.status;
+      }
+      if (updateSpecs.result) {
+        doc.result = updateSpecs.result;
+      }
+      if (updateSpecs.downloadUrl) {
+        doc.downloadUrl = updateSpecs.downloadUrl;
+      }
+      if (updateSpecs.timestamp) {
+        doc.timestamp = updateSpecs.timestamp;
+      }
+      await doc.save();
+      return doc.toObject();
     } catch (e: unknown) {
       console.error("update failed", e);
       throw e;

--- a/backend/src/import/ImportProcessState/importProcessState.types.ts
+++ b/backend/src/import/ImportProcessState/importProcessState.types.ts
@@ -4,7 +4,7 @@ import ImportProcessStateApiSpecs from "api-specifications/importProcessState/";
  * Describes how an import process state is saved in Database
  */
 export interface IImportProcessStateDoc {
-  id: mongoose.Types.ObjectId;
+  id: mongoose.Types.ObjectId; // we add an id field to the document, because we need to provide it upfront when creating a new document
   modelId: mongoose.Types.ObjectId;
   status: ImportProcessStateApiSpecs.Enums.Status;
   result: ImportProcessStateApiSpecs.Types.Result;
@@ -28,4 +28,4 @@ export type INewImportProcessStateSpec = Omit<IImportProcessState, "createdAt" |
 /**
  *  Describes how an import process state is updated with the API
  */
-export type IUpdateImportProcessStateSpec = Omit<IImportProcessState, "id" | "modelId" | "createdAt" | "updatedAt">;
+export type IUpdateImportProcessStateSpec = Partial<Omit<IImportProcessStateDoc, "id" | "modelId">>;

--- a/backend/src/import/ImportProcessState/importProcessStateRepository.test.ts
+++ b/backend/src/import/ImportProcessState/importProcessStateRepository.test.ts
@@ -139,6 +139,46 @@ describe("Test the ImportProcessState Repository with an in-memory mongodb", () 
       });
     });
 
+    test("should successfully update an ImportProcessState status", async () => {
+      // GIVEN an ImportProcessState in the database
+      const givenNewImportProcessStateSpec = getNewImportProcessStatusSpec();
+      const createdImportProcessState = await repository.create(givenNewImportProcessStateSpec);
+
+      // WHEN updating ImportProcessState
+      const updatedImportProcessState = await repository.update(createdImportProcessState.id, {
+        status: ImportProcessStateApiSpecs.Enums.Status.COMPLETED,
+      });
+
+      // THEN expect the updated ImportProcessState to match the given spec
+      expect(updatedImportProcessState).toEqual({
+        ...expectedFromGivenSpec(givenNewImportProcessStateSpec),
+        status: ImportProcessStateApiSpecs.Enums.Status.COMPLETED,
+      });
+    });
+
+    test("should successfully update an ImportProcessState result", async () => {
+      // GIVEN an ImportProcessState in the database
+      const givenNewImportProcessStateSpec = getNewImportProcessStatusSpec();
+      const createdImportProcessState = await repository.create(givenNewImportProcessStateSpec);
+      // AND a result
+      const givenResult = {
+        errored: false,
+        parsingErrors: false,
+        parsingWarnings: true,
+      };
+
+      // WHEN updating the ImportProcessState
+      const updatedImportProcessState = await repository.update(createdImportProcessState.id, {
+        result: givenResult,
+      });
+
+      // THEN expect the updated ImportProcessState to match the given spec
+      expect(updatedImportProcessState).toEqual({
+        ...expectedFromGivenSpec(givenNewImportProcessStateSpec),
+        result: givenResult,
+      });
+    });
+
     test("should reject with an error when updating an ImportProcessState that does not exist", async () => {
       // GIVEN an id of  ImportProcessState that does not exist
       const givenId = getMockStringId(1);


### PR DESCRIPTION
... to use findById() and save() instead of updateOne()