### PR TITLE
chore(api-spec): extend modelInfo api-specs to include createdAt and updatedAt in the importProcessState and exportProcessState fields

### DIFF
--- a/api-specifications/src/exportProcessState/schema.GET.response.ts
+++ b/api-specifications/src/exportProcessState/schema.GET.response.ts
@@ -54,6 +54,8 @@ export const baseExportProcessStateProperties = {
     type: "string",
     format: "date-time",
   },
+  createdAt: { type: "string", format: "date-time" },
+  updatedAt: { type: "string", format: "date-time" },
 };
 
 const SchemaGETResponse: SchemaObject = {
@@ -69,8 +71,6 @@ const SchemaGETResponse: SchemaObject = {
       type: "string",
       pattern: RegExp_Str_ID,
     },
-    createdAt: { type: "string", format: "date-time" },
-    updatedAt: { type: "string", format: "date-time" },
     //Will also have additional properties like stats...
   },
   required: ["id", "modelId", "status", "result", "downloadUrl", "timestamp", "createdAt", "updatedAt"],

--- a/api-specifications/src/importProcessState/schema.GET.response.ts
+++ b/api-specifications/src/importProcessState/schema.GET.response.ts
@@ -34,6 +34,8 @@ export const baseImportProcessStateProperties = {
     },
     required: ["errored", "parsingErrors", "parsingWarnings"],
   },
+  createdAt: { type: "string", format: "date-time" },
+  updatedAt: { type: "string", format: "date-time" },
 };
 
 const SchemaGETResponse: SchemaObject = {
@@ -49,8 +51,6 @@ const SchemaGETResponse: SchemaObject = {
       type: "string",
       pattern: RegExp_Str_ID,
     },
-    createdAt: { type: "string", format: "date-time" },
-    updatedAt: { type: "string", format: "date-time" },
     //Will also have additional properties like stats...
   },
   required: ["id", "modelId", "status", "result", "createdAt", "updatedAt"],

--- a/api-specifications/src/modelInfo/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/modelInfo/__snapshots__/index.test.ts.snap
@@ -63,6 +63,10 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
                 "items": {
                   "additionalProperties": false,
                   "properties": {
+                    "createdAt": {
+                      "format": "date-time",
+                      "type": "string",
+                    },
                     "downloadUrl": {
                       "anyOf": [
                         {
@@ -120,6 +124,10 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
                       "format": "date-time",
                       "type": "string",
                     },
+                    "updatedAt": {
+                      "format": "date-time",
+                      "type": "string",
+                    },
                   },
                   "required": [
                     "id",
@@ -127,6 +135,8 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
                     "downloadUrl",
                     "timestamp",
                     "result",
+                    "createdAt",
+                    "updatedAt",
                   ],
                   "type": "object",
                 },
@@ -142,6 +152,10 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
                 "additionalProperties": false,
                 "description": "The import process state of the model.",
                 "properties": {
+                  "createdAt": {
+                    "format": "date-time",
+                    "type": "string",
+                  },
                   "id": {
                     "description": "The identifier of the specific import state.",
                     "pattern": "^[0-9a-f]{24}$",
@@ -178,6 +192,10 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
                       "running",
                       "completed",
                     ],
+                    "type": "string",
+                  },
+                  "updatedAt": {
+                    "format": "date-time",
                     "type": "string",
                   },
                 },
@@ -325,6 +343,10 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
               "items": {
                 "additionalProperties": false,
                 "properties": {
+                  "createdAt": {
+                    "format": "date-time",
+                    "type": "string",
+                  },
                   "downloadUrl": {
                     "anyOf": [
                       {
@@ -382,6 +404,10 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
                     "format": "date-time",
                     "type": "string",
                   },
+                  "updatedAt": {
+                    "format": "date-time",
+                    "type": "string",
+                  },
                 },
                 "required": [
                   "id",
@@ -389,6 +415,8 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
                   "downloadUrl",
                   "timestamp",
                   "result",
+                  "createdAt",
+                  "updatedAt",
                 ],
                 "type": "object",
               },
@@ -404,6 +432,10 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
               "additionalProperties": false,
               "description": "The import process state of the model.",
               "properties": {
+                "createdAt": {
+                  "format": "date-time",
+                  "type": "string",
+                },
                 "id": {
                   "description": "The identifier of the specific import state.",
                   "pattern": "^[0-9a-f]{24}$",
@@ -440,6 +472,10 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
                     "running",
                     "completed",
                   ],
+                  "type": "string",
+                },
+                "updatedAt": {
+                  "format": "date-time",
                   "type": "string",
                 },
               },

--- a/api-specifications/src/modelInfo/schema.GET.response.test.ts
+++ b/api-specifications/src/modelInfo/schema.GET.response.test.ts
@@ -53,6 +53,19 @@ describe("Test objects against the ModelInfoAPISpecs.Schemas.GET.Response.Payloa
     },
     downloadUrl: "https://foo/bar",
     timestamp: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  const givenImportProcessState = {
+    id: getMockId(1),
+    status: ImportProcessState.Enums.Status.PENDING,
+    result: {
+      errored: false,
+      parsingErrors: false,
+      parsingWarnings: false,
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
   };
   const givenValidModelInfoGETResponse = {
     id: getMockId(1),
@@ -71,15 +84,7 @@ describe("Test objects against the ModelInfoAPISpecs.Schemas.GET.Response.Payloa
     released: false,
     version: getTestString(ModelInfoAPISpecs.Constants.VERSION_MAX_LENGTH),
     exportProcessState: [givenExportProcessState],
-    importProcessState: {
-      id: getMockId(1),
-      status: ImportProcessState.Enums.Status.PENDING,
-      result: {
-        errored: false,
-        parsingErrors: false,
-        parsingWarnings: false,
-      },
-    },
+    importProcessState: givenImportProcessState,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   };
@@ -423,6 +428,56 @@ describe("Test objects against the ModelInfoAPISpecs.Schemas.GET.Response.Payloa
           }
         );
       });
+
+      describe("Test validation of 'exportProcessState/createdAt'", () => {
+        test.each(getStdTimestampFieldTestCases("/exportProcessState/0/createdAt"))(
+          `(%s) Validate createdAt when it is %s`,
+          (caseType, _description, givenValue, failureMessages) => {
+            // GIVEN an object with the given value
+            const givenObject = {
+              exportProcessState: [
+                {
+                  createdAt: givenValue,
+                },
+              ],
+            };
+            // THEN expect the object to validate accordingly
+            assertCaseForProperty(
+              "/exportProcessState/0/createdAt",
+              givenObject,
+              givenSchema,
+              caseType,
+              failureMessages,
+              [LocaleAPISpecs.Schemas.Payload]
+            );
+          }
+        );
+      });
+
+      describe("Test validation of 'exportProcessState/updatedAt'", () => {
+        test.each(getStdTimestampFieldTestCases("/exportProcessState/0/updatedAt"))(
+          `(%s) Validate updatedAt when it is %s`,
+          (caseType, _description, givenValue, failureMessages) => {
+            // GIVEN an object with the given value
+            const givenObject = {
+              exportProcessState: [
+                {
+                  updatedAt: givenValue,
+                },
+              ],
+            };
+            // THEN expect the object to validate accordingly
+            assertCaseForProperty(
+              "/exportProcessState/0/updatedAt",
+              givenObject,
+              givenSchema,
+              caseType,
+              failureMessages,
+              [LocaleAPISpecs.Schemas.Payload]
+            );
+          }
+        );
+      });
     });
 
     describe("Test validation of 'importProcessState'", () => {
@@ -474,6 +529,66 @@ describe("Test objects against the ModelInfoAPISpecs.Schemas.GET.Response.Payloa
         testBooleanField("importProcessState/result/errored", givenSchema, [LocaleAPISpecs.Schemas.Payload]);
         testBooleanField("importProcessState/result/parsingErrors", givenSchema, [LocaleAPISpecs.Schemas.Payload]);
         testBooleanField("importProcessState/result/parsingWarnings", givenSchema, [LocaleAPISpecs.Schemas.Payload]);
+      });
+
+      describe("Test validation of 'importProcessState/createdAt'", () => {
+        test.each([
+          // we are using the standard stdTimestampFieldTestCases but we are filtering out the cases that are not applicable
+          // in this case, since the createdAt field can be undefined we filter out the "undefined" case
+          // and override it with our own case
+          ...(getStdTimestampFieldTestCases("/importProcessState/createdAt").filter(testCase => testCase[1] !== "undefined")),
+          [CaseType.Success, "undefined", undefined, undefined],
+        ])(
+          `(%s) Validate createdAt when it is %s`,
+          (caseType, _description, givenValue, failureMessages) => {
+            // GIVEN an object with the given value
+            const givenObject = {
+              importProcessState: {
+                createdAt: givenValue,
+              },
+            };
+            // THEN expect the object to validate accordingly
+            assertCaseForProperty(
+              "/importProcessState/createdAt",
+              givenObject,
+              givenSchema,
+              caseType,
+              failureMessages,
+              [LocaleAPISpecs.Schemas.Payload]
+            );
+          }
+        );
+      });
+
+      describe("Test validation of 'importProcessState/updatedAt'", () => {
+        test.each(
+          [
+            // we are using the standard stdTimestampFieldTestCases but we are filtering out the cases that are not applicable
+            // in this case, since the updatedAt field can be undefined, we filter out the "undefined" case
+            // and override them with our own cases
+            ...(getStdTimestampFieldTestCases("/importProcessState/updatedAt").filter(testCase => testCase[1] !== "undefined")),
+            [CaseType.Success, "undefined", undefined, undefined]
+          ]
+        )(
+          `(%s) Validate createdAt when it is %s`,
+          (caseType, _description, givenValue, failureMessages) => {
+            // GIVEN an object with the given value
+            const givenObject = {
+              importProcessState: {
+                updatedAt: givenValue,
+              },
+            };
+            // THEN expect the object to validate accordingly
+            assertCaseForProperty(
+              "/importProcessState/updatedAt",
+              givenObject,
+              givenSchema,
+              caseType,
+              failureMessages,
+              [LocaleAPISpecs.Schemas.Payload]
+            );
+          }
+        );
       });
     });
   });

--- a/api-specifications/src/modelInfo/schema.POST.response.test.ts
+++ b/api-specifications/src/modelInfo/schema.POST.response.test.ts
@@ -52,6 +52,19 @@ describe("Test objects against the  ModelInfoAPISpecs.Schemas.POST.Response.Payl
     },
     downloadUrl: "https://foo/bar",
     timestamp: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  const givenImportProcessState = {
+    id: getMockId(1),
+    status: ImportProcessState.Enums.Status.PENDING,
+    result: {
+      errored: false,
+      parsingErrors: false,
+      parsingWarnings: false,
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
   };
   const givenValidModelInfoPOSTResponse = {
     id: getMockId(1),
@@ -70,15 +83,7 @@ describe("Test objects against the  ModelInfoAPISpecs.Schemas.POST.Response.Payl
     released: false,
     version: getTestString(ModelInfoAPISpecs.Constants.VERSION_MAX_LENGTH),
     exportProcessState: [givenExportProcessState],
-    importProcessState: {
-      id: getMockId(1),
-      status: ImportProcessState.Enums.Status.PENDING,
-      result: {
-        errored: false,
-        parsingErrors: false,
-        parsingWarnings: false,
-      },
-    },
+    importProcessState: givenImportProcessState,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   };
@@ -232,7 +237,7 @@ describe("Test objects against the  ModelInfoAPISpecs.Schemas.POST.Response.Payl
         ],
         [
           CaseType.Failure,
-          "a valid exportProcessState object",
+          "a valid exportProcessState object (not array)",
           {
             id: getMockId(1),
             status: ExportProcessStateAPISpecs.Enums.Status.PENDING,
@@ -243,6 +248,8 @@ describe("Test objects against the  ModelInfoAPISpecs.Schemas.POST.Response.Payl
             },
             downloadUrl: "https://foo.bar.com",
             timestamp: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
           },
           constructSchemaError("/exportProcessState", "type", "must be array"),
         ],
@@ -261,6 +268,8 @@ describe("Test objects against the  ModelInfoAPISpecs.Schemas.POST.Response.Payl
               },
               downloadUrl: "https://foo.bar.com",
               timestamp: new Date().toISOString(),
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
             },
           ],
           undefined,
@@ -438,6 +447,54 @@ describe("Test objects against the  ModelInfoAPISpecs.Schemas.POST.Response.Payl
           }
         );
       });
+      describe("Test validation of 'exportProcessState/createdAt'", () => {
+        test.each(getStdTimestampFieldTestCases("/exportProcessState/0/createdAt"))(
+          `(%s) Validate createdAt when it is %s`,
+          (caseType, _description, givenValue, failureMessages) => {
+            // GIVEN an object with the given value
+            const givenObject = {
+              exportProcessState: [
+                {
+                  createdAt: givenValue,
+                },
+              ],
+            };
+            // THEN expect the object to validate accordingly
+            assertCaseForProperty(
+              "/exportProcessState/0/createdAt",
+              givenObject,
+              ModelInfoAPISpecs.Schemas.POST.Response.Payload,
+              caseType,
+              failureMessages,
+              [LocaleAPISpecs.Schemas.Payload]
+            );
+          }
+        );
+      });
+      describe("Test validation of 'exportProcessState/updatedAt'", () => {
+        test.each(getStdTimestampFieldTestCases("/exportProcessState/0/updatedAt"))(
+          `(%s) Validate updatedAt when it is %s`,
+          (caseType, _description, givenValue, failureMessages) => {
+            // GIVEN an object with the given value
+            const givenObject = {
+              exportProcessState: [
+                {
+                  updatedAt: givenValue,
+                },
+              ],
+            };
+            // THEN expect the object to validate accordingly
+            assertCaseForProperty(
+              "/exportProcessState/0/updatedAt",
+              givenObject,
+              ModelInfoAPISpecs.Schemas.POST.Response.Payload,
+              caseType,
+              failureMessages,
+              [LocaleAPISpecs.Schemas.Payload]
+            );
+          }
+        );
+      });
     });
 
     describe("Test validation of 'importProcessState'", () => {
@@ -467,6 +524,8 @@ describe("Test objects against the  ModelInfoAPISpecs.Schemas.POST.Response.Payl
               parsingErrors: false,
               parsingWarnings: false,
             },
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
           },
           undefined,
         ],
@@ -513,6 +572,68 @@ describe("Test objects against the  ModelInfoAPISpecs.Schemas.POST.Response.Payl
         testBooleanField("importProcessState/result/parsingWarnings", ModelInfoAPISpecs.Schemas.POST.Response.Payload, [
           LocaleAPISpecs.Schemas.Payload,
         ]);
+      });
+
+      describe("Test validation of 'importProcessState/createdAt'", () => {
+        test.each(
+          [
+            // we are using the standard stdTimestampFieldTestCases but we are filtering out the cases that are not applicable
+            // in this case, since the createdAt field can be undefined, we filter out the "undefined" case
+            // and override it with our own case
+            ...(getStdTimestampFieldTestCases("/importProcessState/createdAt").filter(testCase => testCase[1] !== "undefined")),
+            [CaseType.Success, "undefined", undefined, undefined],
+          ]
+        )(
+          `(%s) Validate createdAt when it is %s`,
+          (caseType, _description, givenValue, failureMessages) => {
+            // GIVEN an object with the given value
+            const givenObject = {
+              importProcessState: {
+                createdAt: givenValue,
+              },
+            };
+            // THEN expect the object to validate accordingly
+            assertCaseForProperty(
+              "/importProcessState/createdAt",
+              givenObject,
+              ModelInfoAPISpecs.Schemas.POST.Response.Payload,
+              caseType,
+              failureMessages,
+              [LocaleAPISpecs.Schemas.Payload]
+            );
+          }
+        );
+      });
+
+      describe("Test validation of 'importProcessState/updatedAt'", () => {
+        test.each(
+          [
+            // we are using the standard stdTimestampFieldTestCases but we are filtering out the cases that are not applicable
+            // in this case, since the updatedAt field can be undefined, we filter out the "undefined" case
+            // and override it with our own case
+            ...(getStdTimestampFieldTestCases("/importProcessState/updatedAt").filter(testCase => testCase[1] !== "undefined")),
+            [CaseType.Success, "undefined", undefined, undefined],
+          ]
+        )(
+          `(%s) Validate updatedAt when it is %s`,
+          (caseType, _description, givenValue, failureMessages) => {
+            // GIVEN an object with the given value
+            const givenObject = {
+              importProcessState: {
+                updatedAt: givenValue,
+              },
+            };
+            // THEN expect the object to validate accordingly
+            assertCaseForProperty(
+              "/importProcessState/updatedAt",
+              givenObject,
+              ModelInfoAPISpecs.Schemas.POST.Response.Payload,
+              caseType,
+              failureMessages,
+              [LocaleAPISpecs.Schemas.Payload]
+            );
+          }
+        );
       });
     });
   });

--- a/api-specifications/src/modelInfo/schemas.base.ts
+++ b/api-specifications/src/modelInfo/schemas.base.ts
@@ -87,14 +87,16 @@ export const _baseResponseSchema = {
         type: "object",
         additionalProperties: false,
         properties: { ...JSON.parse(JSON.stringify(baseExportProcessStateProperties)) }, // deep copy the base exportProcessState properties
-        required: ["id", "status", "downloadUrl", "timestamp", "result"],
+        required: ["id", "status", "downloadUrl", "timestamp", "result", "createdAt", "updatedAt"],
       },
     },
     importProcessState: {
       description: "The import process state of the model.",
       type: "object",
       additionalProperties: false,
-      properties: { ...JSON.parse(JSON.stringify(baseImportProcessStateProperties)) }, // deep copy the base importProcessState properties
+      properties: {
+        ...JSON.parse(JSON.stringify(baseImportProcessStateProperties)),
+      }, // deep copy the base importProcessState properties
       required: ["id", "status", "result"],
     },
     createdAt: { type: "string", format: "date-time" },

--- a/api-specifications/src/modelInfo/types.ts
+++ b/api-specifications/src/modelInfo/types.ts
@@ -22,6 +22,8 @@ interface IModelInfoResponse extends IModelInfoRequest {
     };
     downloadUrl: string;
     timestamp: string;
+    createdAt: string;
+    updatedAt: string;
   }[];
   importProcessState: {
     id: string;
@@ -31,6 +33,8 @@ interface IModelInfoResponse extends IModelInfoRequest {
       parsingErrors: boolean;
       parsingWarnings: boolean;
     };
+    createdAt?: string;
+    updatedAt?: string;
   };
   createdAt: string;
   updatedAt: string;

--- a/backend/src/export/exportProcessState/exportProcessState.types.ts
+++ b/backend/src/export/exportProcessState/exportProcessState.types.ts
@@ -7,6 +7,8 @@ export interface IExportProcessStateDoc {
   result: ExportProcessStateApiSpecs.Types.Result;
   downloadUrl: string;
   timestamp: Date;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface IExportProcessState extends Omit<IExportProcessStateDoc, "modelId"> {

--- a/backend/src/export/exportProcessState/exportProcessStateModel.test.ts
+++ b/backend/src/export/exportProcessState/exportProcessStateModel.test.ts
@@ -40,6 +40,8 @@ describe("Test the definition of ExportProcessState Model", () => {
       },
       downloadUrl: "https://example.com",
       timestamp: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
     };
     // AND an ExportProcessState document based on the given object
     const givenExportStateDocument = new model(givenObject);

--- a/backend/src/export/modelInfo/modelInfoToCSVTransform.test.ts
+++ b/backend/src/export/modelInfo/modelInfoToCSVTransform.test.ts
@@ -19,6 +19,8 @@ const getMockModelInfo = (i: number): IModelInfo => {
       id: "",
       result: { errored: false, parsingErrors: false, parsingWarnings: false },
       status: ImportProcessStateAPISpecs.Enums.Status.PENDING,
+      createdAt: new Date(),
+      updatedAt: new Date(),
     },
     id: getMockStringId(i),
     UUID: `uuid_${i}`,

--- a/backend/src/import/ImportProcessState/importProcessState.types.ts
+++ b/backend/src/import/ImportProcessState/importProcessState.types.ts
@@ -8,16 +8,19 @@ export interface IImportProcessStateDoc {
   modelId: mongoose.Types.ObjectId;
   status: ImportProcessStateApiSpecs.Enums.Status;
   result: ImportProcessStateApiSpecs.Types.Result;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 /**
  * Describes how an import process state is returned from the API
  */
-export interface IImportProcessState extends Omit<IImportProcessStateDoc, "id" | "modelId"> {
+export interface IImportProcessState
+  extends Omit<IImportProcessStateDoc, "id" | "modelId" | "createdAt" | "updatedAt"> {
   id: string;
   modelId: string;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: string;
+  updatedAt: string;
 }
 
 /**

--- a/backend/src/import/ImportProcessState/importProcessStateModel.test.ts
+++ b/backend/src/import/ImportProcessState/importProcessStateModel.test.ts
@@ -41,6 +41,8 @@ describe("Test the definition of the ImportProcessState Model", () => {
         parsingErrors: false,
         parsingWarnings: false,
       },
+      createdAt: new Date(),
+      updatedAt: new Date(),
     };
     const givenImportStateDocument = new model(givenObject);
 

--- a/backend/src/modelInfo/modelInfo.types.ts
+++ b/backend/src/modelInfo/modelInfo.types.ts
@@ -42,6 +42,8 @@ export interface IModelInfo extends Omit<IModelInfoDoc, "modelId" | "importProce
     };
     downloadUrl: string;
     timestamp: Date;
+    createdAt: Date;
+    updatedAt: Date;
   }[];
   importProcessState: {
     id: string;
@@ -51,6 +53,8 @@ export interface IModelInfo extends Omit<IModelInfoDoc, "modelId" | "importProce
       parsingErrors: boolean;
       parsingWarnings: boolean;
     };
+    createdAt?: Date;
+    updatedAt?: Date;
   };
   createdAt: Date;
   updatedAt: Date;

--- a/backend/src/modelInfo/modelInfoRepository.test.ts
+++ b/backend/src/modelInfo/modelInfoRepository.test.ts
@@ -377,6 +377,8 @@ describe("Test the Model Repository with an in-memory mongodb", () => {
             status: givenExportProcessState.status,
             result: givenExportProcessState.result,
             timestamp: expect.any(Date),
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
           });
         });
       }

--- a/backend/src/modelInfo/populateExportProcessStateOptions.ts
+++ b/backend/src/modelInfo/populateExportProcessStateOptions.ts
@@ -11,6 +11,8 @@ export const populateExportProcessStateOptions = {
       result: doc.result,
       downloadUrl: doc.downloadUrl,
       timestamp: doc.timestamp,
+      createdAt: doc.createdAt,
+      updatedAt: doc.updatedAt,
     };
   },
 };

--- a/backend/src/modelInfo/populateImportProcessStateOptions.test.ts
+++ b/backend/src/modelInfo/populateImportProcessStateOptions.test.ts
@@ -164,6 +164,8 @@ describe("Test populating the ModelInfo.ImportProcessState with an in-memory mon
         id: givenImportProcessState.id,
         status: givenImportProcessState.status,
         result: givenImportProcessState.result,
+        createdAt: givenImportProcessState.createdAt,
+        updatedAt: givenImportProcessState.updatedAt,
       });
     });
 
@@ -178,6 +180,8 @@ describe("Test populating the ModelInfo.ImportProcessState with an in-memory mon
         id: givenImportProcessState.id,
         status: givenImportProcessState.status,
         result: givenImportProcessState.result,
+        createdAt: givenImportProcessState.createdAt,
+        updatedAt: givenImportProcessState.updatedAt,
       });
     });
 
@@ -191,6 +195,8 @@ describe("Test populating the ModelInfo.ImportProcessState with an in-memory mon
         id: givenImportProcessState.id,
         status: givenImportProcessState.status,
         result: givenImportProcessState.result,
+        createdAt: givenImportProcessState.createdAt,
+        updatedAt: givenImportProcessState.updatedAt,
       });
     });
   });

--- a/backend/src/modelInfo/populateImportProcessStateOptions.ts
+++ b/backend/src/modelInfo/populateImportProcessStateOptions.ts
@@ -23,6 +23,8 @@ export const populateImportProcessStateOptions = {
         id: _id.toString(),
         status: doc.status,
         result: doc.result,
+        createdAt: doc.createdAt,
+        updatedAt: doc.updatedAt,
       };
     }
   },

--- a/backend/src/modelInfo/testDataHelper.ts
+++ b/backend/src/modelInfo/testDataHelper.ts
@@ -30,6 +30,8 @@ export function getIModelInfoMockData(n: number = 1): IModelInfo {
         parsingErrors: false,
         parsingWarnings: false,
       },
+      createdAt: new Date(),
+      updatedAt: new Date(),
     },
     exportProcessState: [
       {
@@ -42,6 +44,8 @@ export function getIModelInfoMockData(n: number = 1): IModelInfo {
         },
         downloadUrl: "https://foo.bar/" + n,
         timestamp: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
       },
     ],
     createdAt: new Date(1973, 11, 17, 0, 0, 0), //.toISOString(),

--- a/backend/src/modelInfo/transform.test.ts
+++ b/backend/src/modelInfo/transform.test.ts
@@ -22,7 +22,15 @@ describe("test the transformation of the IIModelInfo -> IModelInfoResponse", () 
       exportProcessState: givenObject.exportProcessState.map((exportProcessState) => ({
         ...exportProcessState,
         timestamp: exportProcessState.timestamp.toISOString(),
+        createdAt: exportProcessState.createdAt.toISOString(),
+        updatedAt: exportProcessState.updatedAt.toISOString(),
       })),
+      // AND the importProcessState as an object with the same properties
+      importProcessState: {
+        ...givenObject.importProcessState,
+        createdAt: givenObject.importProcessState.createdAt!.toISOString(),
+        updatedAt: givenObject.importProcessState.updatedAt!.toISOString(),
+      },
       // AND the path and tabiya path as based on the given base path
       path: `${givenBasePath}${Routes.MODELS_ROUTE}/${givenObject.id}`,
       tabiyaPath: `${givenBasePath}${Routes.MODELS_ROUTE}/${givenObject.UUID}`,

--- a/backend/src/modelInfo/transform.ts
+++ b/backend/src/modelInfo/transform.ts
@@ -18,8 +18,16 @@ export function transform(data: IModelInfo, baseURL: string): ModelInfoAPISpecs.
     exportProcessState: data.exportProcessState.map((exportProcessState) => ({
       ...exportProcessState,
       timestamp: exportProcessState.timestamp.toISOString(),
+      createdAt: exportProcessState.createdAt.toISOString(),
+      updatedAt: exportProcessState.updatedAt.toISOString(),
     })),
-    importProcessState: data.importProcessState,
+    importProcessState: {
+      ...data.importProcessState,
+      // in the case that the model is created but not imported, the createdAt and updatedAt are undefined
+      // we have to check for that and respond accordingly
+      createdAt: data.importProcessState.createdAt ? data.importProcessState.createdAt.toISOString() : undefined,
+      updatedAt: data.importProcessState.updatedAt ? data.importProcessState.updatedAt.toISOString() : undefined,
+    },
     createdAt: data.createdAt.toISOString(),
     updatedAt: data.updatedAt.toISOString(),
   };

--- a/frontend/src/modelInfo/_test_utilities/mockModelInfoPayload.ts
+++ b/frontend/src/modelInfo/_test_utilities/mockModelInfoPayload.ts
@@ -76,6 +76,8 @@ export namespace GET {
             },
             downloadUrl: faker.internet.url(),
             timestamp: new Date().toISOString(),
+            createdAt: new Date(new Date().getTime() - 60000).toISOString(), // make createdAt 1 minute ago and different from updatedAt
+            updatedAt: new Date().toISOString(),
           },
         ],
         importProcessState: {
@@ -86,6 +88,8 @@ export namespace GET {
             parsingErrors: faker.datatype.boolean(),
             parsingWarnings: faker.datatype.boolean(),
           },
+          createdAt: new Date(new Date().getTime() - 60000).toISOString(), // make createdAt 1 minute ago and different from updatedAt
+          updatedAt: new Date().toISOString(),
         },
         createdAt: new Date(Date.now() - i * 1000 * 60 * 60 * 24).toISOString(),
         updatedAt: new Date().toISOString(),
@@ -134,6 +138,8 @@ export function getRandomModelInfo(_id: number): PayloadItem<ModelInfoAPISpecs.T
         },
         downloadUrl: _id % 2 === 0 ? "" : "https://foo/bar/baz", // errored models don't have downloadUrl
         timestamp: new Date().toISOString(),
+        createdAt: new Date(new Date().getTime() - 60000).toISOString(), // make createdAt 1 minute ago and different from updatedAt
+        updatedAt: new Date().toISOString(),
       },
     ],
     importProcessState: {
@@ -144,6 +150,8 @@ export function getRandomModelInfo(_id: number): PayloadItem<ModelInfoAPISpecs.T
         parsingErrors: faker.datatype.boolean(),
         parsingWarnings: faker.datatype.boolean(),
       },
+      createdAt: new Date(new Date().getTime() - 60000).toISOString(), // make createdAt 1 minute ago and different from updatedAt
+      updatedAt: new Date().toISOString(),
     },
     createdAt: new Date(new Date().getTime() - 60000).toISOString(), // make createdAt 1 minute ago and different from updatedAt
     updatedAt: new Date().toISOString(),

--- a/frontend/src/modelInfo/modelInfo.service.test.ts
+++ b/frontend/src/modelInfo/modelInfo.service.test.ts
@@ -77,7 +77,14 @@ describe("ModelInfoService", () => {
           exportProcessState: givenModel.exportProcessState.map((givenExportProcessState) => ({
             ...givenExportProcessState,
             timestamp: new Date(givenExportProcessState.timestamp),
+            createdAt: new Date(givenExportProcessState.createdAt),
+            updatedAt: new Date(givenExportProcessState.updatedAt),
           })),
+          importProcessState: {
+            ...givenModel.importProcessState,
+            createdAt: givenModel.importProcessState.createdAt ? new Date(givenModel.importProcessState.createdAt) : undefined,
+            updatedAt: givenModel.importProcessState.updatedAt ? new Date(givenModel.importProcessState.updatedAt) : undefined,
+          },
           createdAt: new Date(givenModel.createdAt),
           updatedAt: new Date(givenModel.updatedAt),
         }); // currently we do not transform the response, so it should be the same
@@ -450,7 +457,14 @@ describe("ModelInfoService", () => {
         exportProcessState: givenResponseBody.exportProcessState.map((givenExportProcessState) => ({
           ...givenExportProcessState,
           timestamp: new Date(givenExportProcessState.timestamp),
+          createdAt: new Date(givenExportProcessState.createdAt),
+          updatedAt: new Date(givenExportProcessState.updatedAt),
         })),
+        importProcessState: {
+          ...givenResponseBody.importProcessState,
+          createdAt: givenResponseBody.importProcessState.createdAt ? new Date(givenResponseBody.importProcessState.createdAt) : undefined,
+          updatedAt: givenResponseBody.importProcessState.updatedAt ? new Date(givenResponseBody.importProcessState.updatedAt) : undefined,
+        },
         createdAt: new Date(givenResponseBody.createdAt),
         updatedAt: new Date(givenResponseBody.updatedAt),
       });

--- a/frontend/src/modelInfo/modelInfo.service.ts
+++ b/frontend/src/modelInfo/modelInfo.service.ts
@@ -212,8 +212,15 @@ export default class ModelInfoService {
         return {
           ...exportProcessState,
           timestamp: new Date(exportProcessState.timestamp),
+          createdAt: new Date(exportProcessState.createdAt),
+          updatedAt: new Date(exportProcessState.updatedAt),
         };
       }),
+      importProcessState: {
+        ...payloadItem.importProcessState,
+        createdAt: payloadItem.importProcessState.createdAt ? new Date(payloadItem.importProcessState.createdAt) : undefined,
+        updatedAt: payloadItem.importProcessState.updatedAt ? new Date(payloadItem.importProcessState.updatedAt) : undefined,
+      },
       createdAt: new Date(payloadItem.createdAt),
       updatedAt: new Date(payloadItem.updatedAt),
     };

--- a/frontend/src/modelInfo/modelInfoTypes.ts
+++ b/frontend/src/modelInfo/modelInfoTypes.ts
@@ -16,6 +16,8 @@ export namespace ModelInfoTypes {
       parsingErrors: boolean;
       parsingWarnings: boolean;
     };
+    createdAt?: Date;
+    updatedAt?: Date;
   };
 
   export type ExportProcessState = {
@@ -28,6 +30,8 @@ export namespace ModelInfoTypes {
     };
     downloadUrl: string;
     timestamp: Date;
+    createdAt: Date;
+    updatedAt: Date;
   };
 
   export type ModelInfo = {

--- a/frontend/src/modeldirectory/components/ExportProcessStateIcon/_test_utilities/exportProcesStateTestData.ts
+++ b/frontend/src/modeldirectory/components/ExportProcessStateIcon/_test_utilities/exportProcesStateTestData.ts
@@ -22,6 +22,8 @@ export const getAllExportProcessStatePermutations = (): ModelInfoTypes.ExportPro
             },
             downloadUrl: "https://example.com",
             timestamp: new Date(allPermutations.length),
+            createdAt: new Date(allPermutations.length),
+            updatedAt: new Date(allPermutations.length),
           });
         });
       });

--- a/frontend/src/modeldirectory/components/ImportProcessStateIcon/_test_utilities/importProcesStateTestData.ts
+++ b/frontend/src/modeldirectory/components/ImportProcessStateIcon/_test_utilities/importProcesStateTestData.ts
@@ -20,6 +20,8 @@ export const getAllImportProcessStatePermutations = (): ModelInfoTypes.ImportPro
               parsingErrors: parsingErrors,
               parsingWarnings: parsingWarnings,
             },
+            createdAt: new Date(allPermutations.length),
+            updatedAt: new Date(allPermutations.length),
           });
         });
       });

--- a/frontend/src/modeldirectory/components/ModelProperties/ModelPropertiesDrawer.test.tsx
+++ b/frontend/src/modeldirectory/components/ModelProperties/ModelPropertiesDrawer.test.tsx
@@ -64,6 +64,8 @@ const testModel: ModelInfoTypes.ModelInfo = {
       parsingErrors: false,
       parsingWarnings: false,
     },
+    createdAt: new Date(),
+    updatedAt: new Date(),
   },
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/frontend/src/modeldirectory/components/ModelsTable/ExportStateCellContent/ExportCellContent.test.tsx
+++ b/frontend/src/modeldirectory/components/ModelsTable/ExportStateCellContent/ExportCellContent.test.tsx
@@ -83,6 +83,8 @@ describe("ExportStateCellContent", () => {
         },
         downloadUrl: randomUUID(),
         timestamp: new Date(timestamp),
+        createdAt: new Date(timestamp),
+        updatedAt: new Date(new Date(timestamp).getTime() + 1000)
       };
     }
 

--- a/frontend/src/modeldirectory/components/ModelsTable/_test_utilities/mockModelData.ts
+++ b/frontend/src/modeldirectory/components/ModelsTable/_test_utilities/mockModelData.ts
@@ -134,6 +134,8 @@ export const fakeModel: ModelInfoTypes.ModelInfo = {
       parsingWarnings: true,
     },
     status: ImportProcessStateEnums.Status.PENDING,
+    createdAt: new Date("2023-10-18T17:35:10.571Z"),
+    updatedAt: new Date("2023-10-18T17:35:12.571Z"),
   },
   exportProcessState: [
     {
@@ -146,6 +148,8 @@ export const fakeModel: ModelInfoTypes.ModelInfo = {
       },
       status: ExportProcessStateAPISpecs.Enums.Status.PENDING,
       timestamp: new Date("2023-10-18T17:35:10.571Z"),
+      createdAt: new Date("2023-10-18T17:35:10.571Z"),
+      updatedAt: new Date("2023-10-18T17:35:12.571Z"),
     },
   ],
   locale: {
@@ -191,6 +195,8 @@ export function getOneFakeExportProcessState(i: number): ModelInfoTypes.ExportPr
     },
     downloadUrl: faker.internet.url(),
     timestamp: new Date(Date.now() - i * 1000 * 60 * 60 * 24),
+    createdAt: new Date(Date.now() - i * 1000 * 60 * 60 * 24),
+    updatedAt: new Date(),
   };
 }
 
@@ -203,5 +209,7 @@ export function getOneFakeImportProcessState(i: number): ModelInfoTypes.ImportPr
       parsingErrors: i % 2 === 0,
       parsingWarnings: i % 2 === 0,
     },
+    createdAt: new Date(Date.now() - i * 1000 * 60 * 60 * 24),
+    updatedAt: new Date(),
   };
 }


### PR DESCRIPTION
 
- adjust api-spec types and schemas
- adjust backend to work with the api-spec changes
- adjust frontend to work with the new backend changes [pulumi up]