### PR TITLE
fix(backend): extend unit test CSVs to cover all possible variations …

### DIFF
--- a/backend/src/esco/common/csvObjectType.test.ts
+++ b/backend/src/esco/common/csvObjectType.test.ts
@@ -17,6 +17,7 @@ import {
   getCSVSignalingValueLabelFromSignallingValueLabel,
   CSVSignallingValueLabel,
   getCSVSignalingValueFromSignallingValue,
+  getSignallingValueFromCSVSignallingValue,
 } from "esco/common/csvObjectTypes";
 import { ReuseLevel, SkillType } from "esco/skill/skills.types";
 import { SkillToSkillRelationType } from "esco/skillToSkillRelation/skillToSkillRelation.types";
@@ -186,11 +187,13 @@ describe("getSignallingValueLabelFromCSVSignallingValueLabel", () => {
     }
   );
 });
-describe("getSignallingValueFromCSVSignallingValue", () => {
-  const randomNumber = Math.floor(Math.random() * 10000);
+describe("getCSVSignallingValueFromSignallingValue", () => {
+  const randomNumber = Math.floor(Math.random());
   test.each([
     [0, "0"],
     [1, "1"],
+    [2, "2"],
+    [-1, "-1"],
     [10000, "10000"],
     [null, ""],
     [undefined, ""],
@@ -204,6 +207,27 @@ describe("getSignallingValueFromCSVSignallingValue", () => {
     }
   );
 });
+
+describe("getSignallingValueFromCSVSignallingValue", () => {
+  const randomNumber = Math.floor(Math.random());
+  test.each([
+    ["0", 0],
+    ["1", 1],
+    ["2", 2],
+    ["10000", 10000],
+    ["-1", -1],
+    ["", null],
+    [randomNumber.toString(), randomNumber],
+  ])(
+    `for CSV Signalling value: '%s', it should return Signalling value: '%s'`,
+    (givenCSVSignallingValue: string, expectedSignallingValue: number | null) => {
+      // GIVEN a CSVSignallingValue
+      // THEN the SignallingValue should be returned
+      expect(getSignallingValueFromCSVSignallingValue(givenCSVSignallingValue)).toBe(expectedSignallingValue);
+    }
+  );
+});
+
 describe("getCSVTypeFromReuseLevel", () => {
   test.each([
     [CSVReuseLevel.SectorSpecific, ReuseLevel.SectorSpecific],

--- a/backend/src/import/esco/occupationToSkillRelation/_test_data_/expected.ts
+++ b/backend/src/import/esco/occupationToSkillRelation/_test_data_/expected.ts
@@ -1,4 +1,4 @@
-import { ObjectTypes } from "esco/common/objectTypes";
+import { ObjectTypes, SignallingValueLabel } from "esco/common/objectTypes";
 
 export const expected = [
   {
@@ -6,31 +6,23 @@ export const expected = [
     requiringOccupationId: "mapped_key_1",
     relationType: "optional",
     requiredSkillId: "mapped_key_2",
-    signallingValueLabel: "low",
-    signallingValue: 0.1,
+    signallingValueLabel: SignallingValueLabel.NONE,
+    signallingValue: null,
   },
   {
     requiringOccupationType: ObjectTypes.ESCOOccupation,
     requiringOccupationId: "mapped_key_3",
     relationType: "essential",
     requiredSkillId: "mapped_key_4",
-    signallingValueLabel: "medium",
-    signallingValue: 0.5,
+    signallingValueLabel: SignallingValueLabel.NONE,
+    signallingValue: null,
   },
   {
     requiringOccupationType: ObjectTypes.LocalOccupation,
     requiringOccupationId: "mapped_key_7",
     relationType: "essential",
     requiredSkillId: "mapped_key_8",
-    signallingValueLabel: "high",
-    signallingValue: 1,
-  },
-  {
-    requiringOccupationType: ObjectTypes.ESCOOccupation,
-    requiringOccupationId: "mapped_key_15",
-    relationType: "",
-    requiredSkillId: "mapped_key_16",
-    signallingValueLabel: "",
+    signallingValueLabel: SignallingValueLabel.NONE,
     signallingValue: null,
   },
 ];

--- a/backend/src/import/esco/occupationToSkillRelation/_test_data_/given.csv
+++ b/backend/src/import/esco/occupationToSkillRelation/_test_data_/given.csv
@@ -1,11 +1,17 @@
 OCCUPATIONTYPE,OCCUPATIONID,RELATIONTYPE,SKILLID,SIGNALLINGVALUELABEL,SIGNALLINGVALUE
-escooccupation,key_1,optional,key_2,low,0.1
-escooccupation,key_3,essential,key_4,medium,0.5
+escooccupation,key_1,optional,key_2,,
+escooccupation,key_3,essential,key_4,,
 escooccupation,,optional,key_5,,
 escooccupation,key_6,optional,,low,
-localoccupation,key_7,essential,key_8,high,1
+localoccupation,key_7,essential,key_8,,
 invalid should be ignored,key_9,essential,key_10,high,1
 ,key_11,essential,key_12,medium,0.5
 escooccupation,key_13,invalid relation type should be ignored,key_14,,
 escooccupation,key_15,,key_16,,
-localoccupation,key_17,,key_18,invalid,0.5
+localoccupation,key_17,,key_18,medium,1000
+localoccupation,key_19,,key_20,medium,-1
+localoccupation,key_21,,key_22,medium,2
+localoccupation,key_23,,key_24,medium,foo
+localoccupation,key_25,,key_26,medium,"0,6"
+localoccupation,key_27,,key_28,foo,
+localoccupation,key_29,essential,key_30,medium,

--- a/backend/src/import/esco/occupationToSkillRelation/occupationToSkillRelationParser.test.ts
+++ b/backend/src/import/esco/occupationToSkillRelation/occupationToSkillRelationParser.test.ts
@@ -125,7 +125,7 @@ describe("test parseOccupationToSkillRelation from", () => {
       expect(errorLogger.logError).not.toHaveBeenCalled();
 
       // AND warning should be logged for each of the failed rows
-      expect(errorLogger.logWarning).toHaveBeenCalledTimes(6);
+      expect(errorLogger.logWarning).toHaveBeenCalledTimes(13);
       expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
         1,
         `Failed to import OccupationToSkillRelation row with occupationId:'' and skillId:'key_5'.`
@@ -148,7 +148,35 @@ describe("test parseOccupationToSkillRelation from", () => {
       );
       expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
         6,
+        `Failed to import OccupationToSkillRelation row with occupationId:'key_15' and skillId:'key_16'.`
+      );
+      expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
+        7,
         `Failed to import OccupationToSkillRelation row with occupationId:'key_17' and skillId:'key_18'.`
+      );
+      expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
+        8,
+        `Failed to import OccupationToSkillRelation row with occupationId:'key_19' and skillId:'key_20'.`
+      );
+      expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
+        9,
+        `Failed to import OccupationToSkillRelation row with occupationId:'key_21' and skillId:'key_22'.`
+      );
+      expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
+        10,
+        `Failed to import OccupationToSkillRelation row with occupationId:'key_23' and skillId:'key_24'.`
+      );
+      expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
+        11,
+        `Failed to import OccupationToSkillRelation row with occupationId:'key_25' and skillId:'key_26'.`
+      );
+      expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
+        12,
+        `Failed to import OccupationToSkillRelation row with occupationId:'key_27' and skillId:'key_28'.`
+      );
+      expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
+        13,
+        `Failed to import OccupationToSkillRelation row with occupationId:'key_29' and skillId:'key_30'.`
       );
     }
   );

--- a/data-sets/csv/tabiya-sample/occupation_to_skill_relations.csv
+++ b/data-sets/csv/tabiya-sample/occupation_to_skill_relations.csv
@@ -8673,3 +8673,7 @@ escooccupation,key_23426,optional,key_19853,,
 escooccupation,key_23426,optional,key_20015,,
 escooccupation,key_23428,essential,key_19934,,
 escooccupation,key_23428,optional,key_20359,,
+localoccupation,key_20000003,optional,key_19853,,
+localoccupation,key_20000003,,key_20015,low,0
+localoccupation,key_20000003,,key_19934,medium,0.5
+localoccupation,key_20000003,,key_20359,high,1


### PR DESCRIPTION
…of signallingValue fields

- add localOccuaptions with signallingValues to occupationsToSkillsRelations.csv file in tabiya-sample