### PR TITLE
chore(envs): add db sanity checks and Document release

### DIFF
--- a/.github/workflows/approve-deployment.yml
+++ b/.github/workflows/approve-deployment.yml
@@ -2,6 +2,13 @@ name: Request approval
 
 on:
   workflow_call:
+    inputs:
+      tested-version:
+        required: true
+        type: string
+      backend-url:
+        required: true
+        type: string
 
 jobs:
   approve:
@@ -11,3 +18,11 @@ jobs:
       - name: Request approval
         run: echo "Deployment approved"
 
+  db-sanity-checks:
+    needs: approve
+    uses: ./.github/workflows/db-sanity-checks.yml
+    secrets: inherit
+    with:
+      command: assert
+      backend-url: ${{ inputs.backend-url }}
+      version: ${{ inputs.tested-version }}

--- a/.github/workflows/copy-database.yml
+++ b/.github/workflows/copy-database.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   dump-and-restore:
+    name: Database Dump and Restore
     runs-on: ubuntu-latest
     environment: ${{ inputs.target-environment }}
     steps:

--- a/.github/workflows/db-sanity-checks.yml
+++ b/.github/workflows/db-sanity-checks.yml
@@ -1,0 +1,38 @@
+name: Database Sanity Checks
+
+on:
+  workflow_call:
+    outputs:
+      testing-backend-version:
+        description: 'The version of the backend to be tested'
+        value: ${{ jobs.db-sanity-checks.outputs.testing-backend-version }}
+    inputs:
+      command:
+        required: true
+        type: string
+      backend-url:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+
+jobs:
+  db-sanity-checks:
+    runs-on: ubuntu-latest
+    name: DB Sanity Checks
+    outputs:
+      testing-backend-version: ${{ steps.get-current-version.outputs.testing-backend-version }}
+    environment: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: yarn install
+        working-directory: pipeline/scripts
+      - name: Run Database Sanity Checks ${{ inputs.command }}
+        id: get-current-version
+        run: |
+          node ./db-sanity-checks.js ${{ inputs.command }} ${{ inputs.version }} ${{ inputs.backend-url }}/info
+        working-directory: pipeline/scripts
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,11 +12,19 @@ on:
       frontend-version-info:
         required: true
         type: string
+    outputs:
+      backend-url:
+        description: 'The backend URL'
+        value: ${{ jobs.setup-infrastructure.outputs.backend-url }}
+      tested-version:
+        description: 'The tested version'
+        value: ${{ jobs.get-current-version.outputs.testing-backend-version }}
 
 jobs:
   # Copy the target database
   copy-target-database:
     if: ${{ inputs.target-environment == 'test' }}
+    name: Database Dump and Restore
     uses: ./.github/workflows/copy-database.yml
     secrets: inherit
     with:
@@ -28,6 +36,18 @@ jobs:
     secrets: inherit
     with:
       target-environment: ${{ inputs.target-environment }}
+
+  # Copy the target database, the database we are testing.
+  get-current-version:
+    if: ${{ inputs.target-environment == 'test' }}
+    needs: [ setup-infrastructure ]
+    uses: ./.github/workflows/db-sanity-checks.yml
+    name: DB Sanity Checks
+    secrets: inherit
+    with:
+      command: get-current-version
+      backend-url: ${{ needs.setup-infrastructure.outputs.backend-url }}
+      version: $GITHUB_REF_NAME
 
   # Auth
   deploy-auth:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,7 @@ on:
     branches:
       - '**'
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-  release:
-    types:
-      - published
+      - 'v[0-9]+.[0-9]+.[0-9]+' # Semantic version tags
   workflow_dispatch:
 
 jobs:
@@ -32,6 +29,9 @@ jobs:
     needs: [ build, deploy ]
     uses: ./.github/workflows/approve-deployment.yml
     secrets: inherit
+    with:
+      tested-version: ${{ needs.deploy.outputs.tested-version }}
+      backend-url: ${{ needs.deploy.outputs.backend-url }}
 
   deploy-production:
     needs: [ build, require-approval, deploy ]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The Taxonomy Model App is a crucial component of our platform, allowing users to
 - **[Backend](backend)**: Explore the Backend directory for detailed insights about the backend Node.js project.
 - **[Locales](locales)**: Explore the Locales directory for detailed insights about the locales used in the project.
 - **[Contribution Guidelines](#contribution-guidelines)**: Help us improve the project by contributing to various aspects.
+- **[Deployment Guidelines](#deployment-guidelines)**: Help us improve the project by contributing to various aspects.
 - **[Getting Started](#getting-started)**: Easy steps to set up your environment and start contributing.
 - **[License](#license)**: The project is licensed under MIT License.
 - **[@tabiya/prettier-config](%40tabiya%2Fprettier-config)**: The configuration for [prettier](#code-formatting).
@@ -122,6 +123,10 @@ To work with this repository you should have a system with a bash compatible ter
 6. Open a pull request to our main branch.
 
 Happy contributing! 🚀
+
+## Deployment Guidelines
+
+🚀 For deployment guidelines, please refer to the [Deployment Guidelines](deployment-guidelines.md) 🚀
 
 ## License
 

--- a/deployment-guidelines.md
+++ b/deployment-guidelines.md
@@ -1,0 +1,69 @@
+# Taxonomy Model App - Deployment Guidelines
+
+> Here are the guidelines for deploying the Taxonomy Model Application. 
+> These instructions will help you set up the app in development, testing, and production environments.
+
+## Sanity checks.
+
+Before deploying to any environment, make sure the following checks passes.
+
+- **Code Coverage**: 100%
+- **Bugs**: 0
+- **Security Rating**: A
+- **Reliability Rating**: A
+- **Maintainability Rating**: A
+- **Security Hotspots Reviewed**: 100%
+
+### Checks for development environment
+
+- **Unity tests**: 100%
+- **Integration tests**: 100%
+- **End-to-End tests**: 100%
+- **Smoke tests**: 100%
+- **Sonarcloud**: 100%
+
+### Checks for testing environment
+
+> 1. Before deployment on test, we pull the production data to the test environment to make sure the data is up-to-date.
+> Check the job that handles this to understand more about the logic [copy-database.yml](.github/workflows/copy-database.yml)
+
+- All the checks for the development environment
+- **The new tag(version) must follow [Semantic Versioning 2.0.0](https://semver.org/) format. With v at the beginning. For example vZ.Y.X-....**
+- **The release must be created on the repository**
+- **The version must be greater than the last version deployed to the testing environment**
+
+### Checks for production environment 🚀
+
+- **The tested version by test environment must be the same as the version deployed to the production environment**
+- **The new version must be greater than or equal to the last version deployed to the testing environment**
+
+
+## Deploying on development environment
+
+Any push to the main branch are automatically deployed to the development environment. It may be a commit pushed directly to the main or a pull request merged into main. This process ensures that the latest updates are always tested in a live setting. By doing so, it allows for immediate identification and resolution of any issues that may arise.
+
+## Deploying on testing environment
+
+To deploy the app on the testing environment, you have two options
+
+1. Tagging
+   > Create a tag on the main branch and push a tag. A tag must follow [Semantic Versioning 2.0.0](https://semver.org/) format. With v at the beginning. For example vZ.Y.X-....
+   >   
+   > For more information on creating and sharing tags check [the documentation](https://git-scm.com/book/en/v2/Git-Basics-Tagging)
+2. Releases
+   > You can also create a tag from release where you create a new tag. 
+   > 
+   > For more information check [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases): Create a release on the repository, this is going to trigger a deployment to the testing environment.
+
+> **Notes**:
+> Creating a release from an already existing tag won't trigger a deployment to the testing environment. As the deployment was already triggered when the tag was created. But you can re-deploy by refreshing the deployment on the [GitHub Actions page](https://github.com/tabiya-tech/taxonomy-model-application/actions).
+
+## Deploying on production environment
+
+After the deployment on test, a step that requires approval is going to be initiated, once Approved deployment to production is going to follow up. but when it is rejected. no deployment is going to happen. We used [GitHub Protection rules](https://docs.github.com/en/actions/deployment/protecting-deployments/creating-custom-deployment-protection-rules) to enforce this on the confirmation environments.
+
+## Current Deployed Endpoints.
+
+- **Development**: [https://dev.platform.tabiya.tech](https://dev.platform.tabiya.tech)
+- **Testing**: [https://test.platform.tabiya.tech](https://test.platform.tabiya.tech)
+- **Production**: [https://platform.tabiya.tech](https://platform.tabiya.tech)


### PR DESCRIPTION
1. Document release management - PLAT-279
  - Deploying to all environments
2. Sanity checks before deploying to prod - PLAT-280
  - semantic versioning passes (we're not deploying a version that is older than the current version) 
  - check that the version was tested against the same snapshot of production data as the current production data