### PR TITLE
feat(data-sets): add LICENSE file support both on import and export

### DIFF
--- a/api-specifications/src/modelInfo/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/modelInfo/__snapshots__/index.test.ts.snap
@@ -4,7 +4,8 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
 {
   "Constants": {
     "DESCRIPTION_MAX_LENGTH": 4000,
-    "MAX_PAYLOAD_LENGTH": 6000,
+    "LICENSE_MAX_LENGTH": 100000,
+    "MAX_PAYLOAD_LENGTH": 218884,
     "MAX_URI_LENGTH": 4096,
     "NAME_MAX_LENGTH": 256,
     "RELEASE_NOTES_MAX_LENGTH": 100000,
@@ -206,6 +207,11 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
                 ],
                 "type": "object",
               },
+              "license": {
+                "description": "The license of the model",
+                "maxLength": 100000,
+                "type": "string",
+              },
               "locale": {
                 "$ref": "/components/schemas/LocaleSchema",
               },
@@ -309,6 +315,7 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
               "name",
               "description",
               "locale",
+              "license",
               "id",
               "UUID",
               "path",
@@ -348,6 +355,11 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
               "maxLength": 4000,
               "type": "string",
             },
+            "license": {
+              "description": "The license of the model",
+              "maxLength": 100000,
+              "type": "string",
+            },
             "locale": {
               "$ref": "/components/schemas/LocaleSchema",
             },
@@ -362,6 +374,7 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
             "name",
             "description",
             "locale",
+            "license",
             "UUIDHistory",
           ],
           "type": "object",
@@ -543,6 +556,11 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
               ],
               "type": "object",
             },
+            "license": {
+              "description": "The license of the model",
+              "maxLength": 100000,
+              "type": "string",
+            },
             "locale": {
               "$ref": "/components/schemas/LocaleSchema",
             },
@@ -646,6 +664,7 @@ exports[`Test the modelInfo module The export module matches the snapshot 1`] = 
             "name",
             "description",
             "locale",
+            "license",
             "id",
             "UUID",
             "path",

--- a/api-specifications/src/modelInfo/constants.ts
+++ b/api-specifications/src/modelInfo/constants.ts
@@ -1,10 +1,23 @@
+import LocaleConstants  from "../locale/constants";
+
 namespace ModelInfoConstants {
   export const NAME_MAX_LENGTH = 256;
   export const DESCRIPTION_MAX_LENGTH = 4000;
   export const RELEASE_NOTES_MAX_LENGTH = 100000;
+  export const LICENSE_MAX_LENGTH = 100000;
   export const VERSION_MAX_LENGTH = 256;
-  export const MAX_PAYLOAD_LENGTH = 6000;
   export const MAX_URI_LENGTH = 4096;
+
+  export const MAX_PAYLOAD_LENGTH =
+    NAME_MAX_LENGTH +
+    DESCRIPTION_MAX_LENGTH +
+    RELEASE_NOTES_MAX_LENGTH +
+    LICENSE_MAX_LENGTH +
+    VERSION_MAX_LENGTH +
+    MAX_URI_LENGTH +
+    LocaleConstants.LOCALE_SHORTCODE_MAX_LENGTH +
+    LocaleConstants.NAME_MAX_LENGTH +
+    10_000; // For object keys (taken randomly)
 }
 
 export default ModelInfoConstants;

--- a/api-specifications/src/modelInfo/index.test.ts
+++ b/api-specifications/src/modelInfo/index.test.ts
@@ -16,6 +16,7 @@ describe("Test the modelInfo module", () => {
     expect(Constants.DESCRIPTION_MAX_LENGTH).toBeDefined();
     expect(Constants.RELEASE_NOTES_MAX_LENGTH).toBeDefined();
     expect(Constants.VERSION_MAX_LENGTH).toBeDefined();
+    expect(Constants.LICENSE_MAX_LENGTH).toBeDefined();
     expect(Constants.MAX_URI_LENGTH).toBeDefined();
   });
 

--- a/api-specifications/src/modelInfo/schema.GET.response.test.ts
+++ b/api-specifications/src/modelInfo/schema.GET.response.test.ts
@@ -86,6 +86,7 @@ describe("Test objects against the ModelInfoAPISpecs.Schemas.GET.Response.Payloa
     tabiyaPath: "https://path/to/tabiya",
     name: getTestString(ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH),
     description: getTestString(ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH),
+    license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
     locale: {
       name: getTestString(ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH),
       UUID: randomUUID(),
@@ -209,6 +210,15 @@ describe("Test objects against the ModelInfoAPISpecs.Schemas.GET.Response.Payloa
       testStringField<ModelInfoAPISpecs.Types.GET.Response.Payload>(
         "description",
         ModelInfoConstants.DESCRIPTION_MAX_LENGTH,
+        givenSchema,
+        [LocaleAPISpecs.Schemas.Payload]
+      );
+    });
+
+    describe("Test validation of 'license'", () => {
+      testStringField<ModelInfoAPISpecs.Types.GET.Response.Payload>(
+        "license",
+        ModelInfoConstants.LICENSE_MAX_LENGTH,
         givenSchema,
         [LocaleAPISpecs.Schemas.Payload]
       );

--- a/api-specifications/src/modelInfo/schema.POST.request.test.ts
+++ b/api-specifications/src/modelInfo/schema.POST.request.test.ts
@@ -27,6 +27,7 @@ describe("Test objects against the ModelInfoAPISpecs.Schemas.POST.Request.Payloa
   const givenValidModelInfoPOSTRequest = {
     name: getTestString(ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH),
     description: getTestString(ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH),
+    license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
     UUIDHistory: [randomUUID()],
     locale: {
       name: getTestString(ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH),
@@ -79,6 +80,15 @@ describe("Test objects against the ModelInfoAPISpecs.Schemas.POST.Request.Payloa
       testStringField<ModelInfoAPISpecs.Types.POST.Request.Payload>(
         "description",
         ModelInfoConstants.DESCRIPTION_MAX_LENGTH,
+        ModelInfoAPISpecs.Schemas.POST.Request.Payload,
+        [LocaleAPISpecs.Schemas.Payload]
+      );
+    });
+
+    describe("Test validation of 'license'", () => {
+      testStringField<ModelInfoAPISpecs.Types.POST.Request.Payload>(
+        "license",
+        ModelInfoConstants.LICENSE_MAX_LENGTH,
         ModelInfoAPISpecs.Schemas.POST.Request.Payload,
         [LocaleAPISpecs.Schemas.Payload]
       );

--- a/api-specifications/src/modelInfo/schema.POST.request.ts
+++ b/api-specifications/src/modelInfo/schema.POST.request.ts
@@ -8,7 +8,7 @@ const SchemaPOSTRequest: SchemaObject = {
   properties: {
     ...JSON.parse(JSON.stringify(_baseProperties)), // deep copy the base properties
   },
-  required: ["name", "description", "locale", "UUIDHistory"],
+  required: ["name", "description", "locale", "license", "UUIDHistory"],
 };
 
 export default SchemaPOSTRequest;

--- a/api-specifications/src/modelInfo/schema.POST.response.test.ts
+++ b/api-specifications/src/modelInfo/schema.POST.response.test.ts
@@ -85,6 +85,7 @@ describe("Test objects against the  ModelInfoAPISpecs.Schemas.POST.Response.Payl
     tabiyaPath: "https://path/to/tabiya",
     name: getTestString(ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH),
     description: getTestString(ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH),
+    license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
     locale: {
       name: getTestString(ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH),
       UUID: randomUUID(),
@@ -199,6 +200,15 @@ describe("Test objects against the  ModelInfoAPISpecs.Schemas.POST.Response.Payl
       testStringField<ModelInfoAPISpecs.Types.POST.Response.Payload>(
         "description",
         ModelInfoConstants.DESCRIPTION_MAX_LENGTH,
+        ModelInfoAPISpecs.Schemas.POST.Response.Payload,
+        [LocaleAPISpecs.Schemas.Payload]
+      );
+    });
+
+    describe("Test validation of 'license'", () => {
+      testStringField<ModelInfoAPISpecs.Types.POST.Response.Payload>(
+        "license",
+        ModelInfoConstants.LICENSE_MAX_LENGTH,
         ModelInfoAPISpecs.Schemas.POST.Response.Payload,
         [LocaleAPISpecs.Schemas.Payload]
       );

--- a/api-specifications/src/modelInfo/schemas.base.ts
+++ b/api-specifications/src/modelInfo/schemas.base.ts
@@ -24,6 +24,11 @@ export const _baseProperties: any = {
     type: "string",
     maxLength: ModelInfoConstants.DESCRIPTION_MAX_LENGTH,
   },
+  license: {
+    description: "The license of the model",
+    type: "string",
+    maxLength: ModelInfoConstants.LICENSE_MAX_LENGTH,
+  },
   locale: {
     $ref: `${Locale.Schemas.Payload.$id}`,
   },
@@ -147,6 +152,7 @@ export const _baseResponseSchema = {
     "name",
     "description",
     "locale",
+    "license",
     "id",
     "UUID",
     "path",

--- a/api-specifications/src/modelInfo/types.ts
+++ b/api-specifications/src/modelInfo/types.ts
@@ -15,6 +15,7 @@ interface IModelInfoResponse {
   }[];
   name: string;
   description: string;
+  license: string;
   locale: Locale.Types.Payload;
   path: string;
   tabiyaPath: string;
@@ -53,6 +54,7 @@ interface IModelInfoRequest {
   name: string;
   description: string;
   locale: Locale.Types.Payload;
+  license: string;
   UUIDHistory: string[];
 }
 

--- a/backend/src/export/async/modelToS3.test.ts
+++ b/backend/src/export/async/modelToS3.test.ts
@@ -64,6 +64,13 @@ jest.mock("export/modelInfo/modelInfoToCSVTransform", () => {
   });
 });
 
+jest.mock("export/license/licenseToFileTransform", () => {
+  // std mock should return a transform stream with some data
+  return jest.fn().mockImplementation(() => {
+    return Readable.from(["foo", "bar", "baz"], { objectMode: true });
+  });
+});
+
 jest.mock("export/async/CSVtoZipPipeline", () => {
   // std mock should return the actual
   const actualModule = jest.requireActual("export/async/CSVtoZipPipeline");
@@ -162,6 +169,7 @@ import OccupationToSkillRelationToCSVTransform from "export/esco/occupationToSki
 import SkillToSkillRelationToCSVTransform from "export/esco/skillToSkillRelation/skillToSkillRelationToCSVTransform";
 import ModelInfoToCSVTransform from "export/modelInfo/modelInfoToCSVTransform";
 import OccupationsToCSVTransform from "export/esco/occupation/OccupationsToCSVTransform";
+import LicenseToFileTransform from "export/license/licenseToFileTransform";
 
 jest.spyOn(errorLogger, "logError");
 jest.spyOn(errorLogger, "logWarning");
@@ -226,6 +234,7 @@ describe("modelToS3", () => {
       [OccupationToSkillRelationToCSVTransform, FILENAMES.OccupationToSkillRelations],
       [SkillToSkillRelationToCSVTransform, FILENAMES.SkillToSkillRelations],
       [ModelInfoToCSVTransform, FILENAMES.ModelInfo],
+      [LicenseToFileTransform, FILENAMES.License],
     ].forEach(([transform, filename]) => {
       // EXPECT the collection to be transfomred to CSV
       expect(transform).toHaveBeenCalledWith(givenEvent.modelId);
@@ -288,6 +297,7 @@ describe("modelToS3", () => {
       ["OccupationToSkillRelationToCSVTransformStream", OccupationToSkillRelationToCSVTransform],
       ["SkillToSkillRelationToCSVTransformStream", SkillToSkillRelationToCSVTransform],
       ["ModelInfoToCSVTransformStream", ModelInfoToCSVTransform],
+      ["LicenseToFileTransform", LicenseToFileTransform],
     ])("should reject and release resources when the %s emits errors", async (_caseDescription, givenFailingStream) => {
       const failureCallback = () =>
         (givenFailingStream as jest.Mock).mockImplementationOnce(() => {
@@ -298,7 +308,7 @@ describe("modelToS3", () => {
         });
       await testFailure(
         failureCallback,
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "Premature close",
         true
       );
@@ -340,7 +350,7 @@ describe("modelToS3", () => {
       ],
       [
         "OccupationGroupsToCSVTransform throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (OccupationGroupsToCSVTransform as jest.Mock).mockImplementationOnce(() => {
@@ -350,7 +360,7 @@ describe("modelToS3", () => {
       ],
       [
         "OccupationToCSVTransform throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (OccupationsToCSVTransform as jest.Mock).mockImplementationOnce(() => {
@@ -360,7 +370,7 @@ describe("modelToS3", () => {
       ],
       [
         "SkillToCSVTransform throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (SkillsToCSVTransform as jest.Mock).mockImplementationOnce(() => {
@@ -370,7 +380,7 @@ describe("modelToS3", () => {
       ],
       [
         "SkillGroupToCSVTransform throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (SkillGroupsToCSVTransform as jest.Mock).mockImplementationOnce(() => {
@@ -380,7 +390,7 @@ describe("modelToS3", () => {
       ],
       [
         "OccupationHierarchyToCSVTransform throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (OccupationHierarchyToCSVTransform as jest.Mock).mockImplementationOnce(() => {
@@ -390,7 +400,7 @@ describe("modelToS3", () => {
       ],
       [
         "SkillHierarchyToCSVTransform throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (SkillHierarchyToCSVTransform as jest.Mock).mockImplementationOnce(() => {
@@ -400,7 +410,7 @@ describe("modelToS3", () => {
       ],
       [
         "OccupationToSkillRelationToCSVTransform throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (OccupationToSkillRelationToCSVTransform as jest.Mock).mockImplementationOnce(() => {
@@ -410,7 +420,7 @@ describe("modelToS3", () => {
       ],
       [
         "SkillToSkillRelationToCSVTransform throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (SkillToSkillRelationToCSVTransform as jest.Mock).mockImplementationOnce(() => {
@@ -420,7 +430,7 @@ describe("modelToS3", () => {
       ],
       [
         "ModelInfoToCSVTransform throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (ModelInfoToCSVTransform as jest.Mock).mockImplementationOnce(() => {
@@ -429,8 +439,18 @@ describe("modelToS3", () => {
         },
       ],
       [
+        "LicenseToFileTransform throws an error",
+        "An error occurred while streaming data from the DB to the zip file on S3",
+        "foo",
+        () => {
+          (LicenseToFileTransform as jest.Mock).mockImplementationOnce(() => {
+            throw new Error("foo");
+          });
+        },
+      ],
+      [
         "the csvToZipPipeline throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (CSVtoZipPipeline as jest.Mock).mockImplementationOnce(() => {
@@ -440,7 +460,7 @@ describe("modelToS3", () => {
       ],
       [
         "the archiver fails to pipe and throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           callbackArchiverCreated = (zipper) => {
@@ -452,7 +472,7 @@ describe("modelToS3", () => {
       ],
       [
         "the archiver fails to finalize and throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           callbackArchiverCreated = (zipper) => {
@@ -464,7 +484,7 @@ describe("modelToS3", () => {
       ],
       [
         "the archiver fails to finalize and rejects with an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           callbackArchiverCreated = (zipper) => {
@@ -474,7 +494,7 @@ describe("modelToS3", () => {
       ],
       [
         "the uploadToS3 module rejects with an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (uploadZipToS3 as jest.Mock).mockImplementationOnce(() => {
@@ -484,7 +504,7 @@ describe("modelToS3", () => {
       ],
       [
         "the uploadToS3 module throws an error",
-        "An error occurred while streaming data from the DB to the csv zip file on S3",
+        "An error occurred while streaming data from the DB to the zip file on S3",
         "foo",
         () => {
           (uploadZipToS3 as jest.Mock).mockRejectedValueOnce(new Error("foo"));
@@ -584,6 +604,7 @@ async function assertThatAllCreatedResourcesAreReleased(assertCreated: boolean) 
     OccupationToSkillRelationToCSVTransform,
     SkillToSkillRelationToCSVTransform,
     ModelInfoToCSVTransform,
+    LicenseToFileTransform,
   ];
   for (const mock of collectionToCSVTransformMocks) {
     const results = (mock as jest.Mock).mock.results;

--- a/backend/src/export/license/licenseToFileTransform.test.ts
+++ b/backend/src/export/license/licenseToFileTransform.test.ts
@@ -1,0 +1,142 @@
+import { IModelInfo } from "modelInfo/modelInfo.types";
+import { getMockStringId } from "_test_utilities/mockMongoId";
+import { IModelRepository } from "modelInfo/modelInfoRepository";
+import { getTestString } from "_test_utilities/specialCharacters";
+import ImportProcessStateAPISpecs from "api-specifications/importProcessState";
+import { getRepositoryRegistry } from "server/repositoryRegistry/repositoryRegistry";
+
+import LicenseToFileTransform from "./licenseToFileTransform";
+
+const ModelInfoRepository = jest.spyOn(getRepositoryRegistry(), "modelInfo", "get");
+
+const getMockModelInfo = (i: number): IModelInfo => {
+  return {
+    exportProcessState: [],
+    importProcessState: {
+      id: "",
+      result: { errored: false, parsingErrors: false, parsingWarnings: false },
+      status: ImportProcessStateAPISpecs.Enums.Status.PENDING,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    id: getMockStringId(i),
+    UUID: `uuid_${i}`,
+    UUIDHistory: [`uuid_1`, `uuid_2`],
+    name: `name_${i}_${getTestString(10)}`,
+    locale: {
+      UUID: `localeUUID_${i}`,
+      shortCode: `shortCode_${i}`,
+      name: `name_${i}`,
+    },
+    description: `description_${i}_${getTestString(10)}`,
+    license: `license_${i}_${getTestString(10)}`,
+    version: `version_${i}`,
+    released: true,
+    releaseNotes: `releaseNotes_${i}_${getTestString(10)}`,
+    createdAt: new Date(0), // use a fixed date to make the snapshot stable
+    updatedAt: new Date(1), // use a fixed date to make the snapshot stable
+  };
+};
+
+function setupModelInfoRepositoryMock(findByIdFn: () => IModelInfo | null) {
+  const mockModelInfoRepository: IModelRepository = {
+    Model: undefined as never,
+    create: jest.fn().mockResolvedValue(null),
+    getModelById: jest.fn().mockImplementationOnce(findByIdFn),
+    getModels: jest.fn(),
+    getModelByUUID: jest.fn(),
+    getHistory: jest.fn(),
+  };
+  ModelInfoRepository.mockReturnValue(mockModelInfoRepository);
+}
+
+describe("LicenseToFileTransform.test.ts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.each([
+    ["released", true],
+    ["unreleased", false],
+  ])(
+    "should correctly transform ModelInfo data to CSV when model is %s",
+    async (_description: string, givenReleased: boolean) => {
+      // GIVEN findAll returns a stream of ModelInfos
+      const givenModelInfo = getMockModelInfo(2);
+      givenModelInfo.released = givenReleased;
+      setupModelInfoRepositoryMock(() => givenModelInfo);
+
+      // WHEN the transformation is applied
+      const transformedStream = await LicenseToFileTransform(givenModelInfo.id);
+
+      // THEN the output should be a stream
+      const chunks = [];
+      for await (const chunk of transformedStream) {
+        chunks.push(chunk);
+      }
+      const actualLicenseContent = chunks.join("");
+
+      // AND license should be the same
+      expect(actualLicenseContent).toBe(givenModelInfo.license);
+
+      // AND the stream should end
+      expect(transformedStream.closed).toBe(true);
+    }
+  );
+
+  test("it should throw an error if the modelInfo is not found", async () => {
+    // GIVEN findAll returns a stream of ModelInfos
+    setupModelInfoRepositoryMock(() => null);
+
+    // WHEN the transformation is applied
+    await expect(LicenseToFileTransform("")).rejects.toThrow("ModelInfo not found");
+  });
+
+  test("should return empty stream if license is empty", async () => {
+    // GIVEN findAll returns a stream of ModelInfos
+    const givenModelInfo = getMockModelInfo(2);
+    givenModelInfo.license = "";
+    setupModelInfoRepositoryMock(() => givenModelInfo);
+
+    // WHEN the transformation is applied
+    const transformedStream = await LicenseToFileTransform(givenModelInfo.id);
+
+    // THEN the output should be a stream
+    const chunks = [];
+    for await (const chunk of transformedStream) {
+      chunks.push(chunk);
+    }
+
+    const actualLicenseContent = chunks.join("");
+
+    // AND license should be the same
+    expect(actualLicenseContent).toBe(givenModelInfo.license);
+
+    // AND the stream should end
+    expect(transformedStream.closed).toBe(true);
+  });
+
+  test("should return empty stream if license is undefined", async () => {
+    // GIVEN findAll returns a stream of ModelInfos
+    const givenModelInfo = getMockModelInfo(2);
+    givenModelInfo.license = undefined as never;
+    setupModelInfoRepositoryMock(() => givenModelInfo);
+
+    // WHEN the transformation is applied
+    const transformedStream = await LicenseToFileTransform(givenModelInfo.id);
+
+    // THEN the output should be a stream
+    const chunks = [];
+    for await (const chunk of transformedStream) {
+      chunks.push(chunk);
+    }
+
+    const actualLicenseContent = chunks.join("");
+
+    // AND license should be empty string
+    expect(actualLicenseContent).toBe("");
+
+    // AND the stream should end
+    expect(transformedStream.closed).toBe(true);
+  });
+});

--- a/backend/src/export/license/licenseToFileTransform.ts
+++ b/backend/src/export/license/licenseToFileTransform.ts
@@ -1,0 +1,15 @@
+import { Readable } from "node:stream";
+import { getRepositoryRegistry } from "server/repositoryRegistry/repositoryRegistry";
+
+const LicenseToFileTransform = async (modelId: string): Promise<Readable> => {
+  const modelInfo = await getRepositoryRegistry().modelInfo.getModelById(modelId);
+
+  if (!modelInfo) {
+    throw new Error("ModelInfo not found");
+  }
+
+  // return a pipeline with one string.
+  return Readable.from([modelInfo.license]);
+};
+
+export default LicenseToFileTransform;

--- a/backend/src/export/modelInfo/modelInfoToCSVTransform.test.ts
+++ b/backend/src/export/modelInfo/modelInfoToCSVTransform.test.ts
@@ -32,6 +32,7 @@ const getMockModelInfo = (i: number): IModelInfo => {
       name: `name_${i}`,
     },
     description: `description_${i}_${getTestString(10)}`,
+    license: `description_${i}_${getTestString(10)}`,
     version: `version_${i}`,
     released: true,
     releaseNotes: `releaseNotes_${i}_${getTestString(10)}`,

--- a/backend/src/import/async/parseFiles.ts
+++ b/backend/src/import/async/parseFiles.ts
@@ -89,8 +89,10 @@ export const parseFiles = async (event: ImportAPISpecs.Types.POST.Request.Payloa
     const ICATUS_LEVEL_1_GROUPS = 3;
     const ESCO_LEVEL_1_GROUPS = 10;
 
-    const expectedOccupationHierarchyEntriesWithoutICATUS = countOccupationGroups + countOccupations - (ESCO_LEVEL_1_GROUPS);
-    const expectedOccupationHierarchyEntriesWithICATUS = expectedOccupationHierarchyEntriesWithoutICATUS - ICATUS_LEVEL_1_GROUPS;
+    const expectedOccupationHierarchyEntriesWithoutICATUS =
+      countOccupationGroups + countOccupations - ESCO_LEVEL_1_GROUPS;
+    const expectedOccupationHierarchyEntriesWithICATUS =
+      expectedOccupationHierarchyEntriesWithoutICATUS - ICATUS_LEVEL_1_GROUPS;
 
     // For now there are two possible cases:
     // 1. The import contains both ESCO and ICATUS data (10 level 1 isco groups and 3 level 1 icatus groups)
@@ -101,11 +103,7 @@ export const parseFiles = async (event: ImportAPISpecs.Types.POST.Request.Payloa
       stats.rowsSuccess !== expectedOccupationHierarchyEntriesWithICATUS
     ) {
       errorLogger.logWarning(
-        `Expected to successfully process either ${
-          expectedOccupationHierarchyEntriesWithoutICATUS
-        } or ${expectedOccupationHierarchyEntriesWithICATUS} hierarchy entries. Instead processed ${
-          stats.rowsSuccess
-        } entries.`
+        `Expected to successfully process either ${expectedOccupationHierarchyEntriesWithoutICATUS} or ${expectedOccupationHierarchyEntriesWithICATUS} hierarchy entries. Instead processed ${stats.rowsSuccess} entries.`
       );
     }
   }

--- a/backend/src/import/esco/OccupationGroups/OccupationGroupsParser.test.ts
+++ b/backend/src/import/esco/OccupationGroups/OccupationGroupsParser.test.ts
@@ -128,9 +128,9 @@ describe("test parseOccupationGroups from", () => {
       expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
         1,
         "Warning while importing Occupation Group row with id:'key_2'. Preferred label 'preferred\n" +
-        "label\n" +
-        "with\n" +
-        "linebreak' is not in the alt labels."
+          "label\n" +
+          "with\n" +
+          "linebreak' is not in the alt labels."
       );
       expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
         2,

--- a/backend/src/import/esco/occupations/occupationsParser.test.ts
+++ b/backend/src/import/esco/occupations/occupationsParser.test.ts
@@ -149,9 +149,9 @@ describe("test parseOccupations from", () => {
       expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
         3,
         "Warning while importing Occupation row with id:'key_2'. Preferred label 'preferred\n" +
-        "label\n" +
-        "with\n" +
-        "linebreak' is not in the alt labels."
+          "label\n" +
+          "with\n" +
+          "linebreak' is not in the alt labels."
       );
       expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
         4,

--- a/backend/src/import/esco/occupations/occupationsParser.ts
+++ b/backend/src/import/esco/occupations/occupationsParser.ts
@@ -80,7 +80,6 @@ function getRowToSpecificationTransformFn(
       );
     }
 
-
     return {
       originUri: row.ORIGINURI,
       modelId: modelId,

--- a/backend/src/import/esco/skillGroups/skillGroupsParser.test.ts
+++ b/backend/src/import/esco/skillGroups/skillGroupsParser.test.ts
@@ -128,9 +128,9 @@ describe("test parseSkillGroups from", () => {
       expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
         1,
         "Warning while importing Skill Group row with id:'key_2'. Preferred label 'preferred\n" +
-        "label\n" +
-        "with\n" +
-        "linebreak' is not in the alt labels."
+          "label\n" +
+          "with\n" +
+          "linebreak' is not in the alt labels."
       );
       // AND a warning should be logged for the row with duplicate altLabels
       expect(errorLogger.logWarning).toHaveBeenNthCalledWith(

--- a/backend/src/import/esco/skills/skillsParser.test.ts
+++ b/backend/src/import/esco/skills/skillsParser.test.ts
@@ -135,15 +135,15 @@ describe("test parseSkills from", () => {
       );
 
       // AND a warning that that says that the preferred label is not in the alt labels should be logged
-      expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
-        3,
-        "Failed to import Skill with skillId:key_7"
-      );
+      expect(errorLogger.logWarning).toHaveBeenNthCalledWith(3, "Failed to import Skill with skillId:key_7");
       // AND warning should be logged fo reach of the failed rows
-      expect(errorLogger.logWarning).toHaveBeenNthCalledWith(1, "Warning while importing Skill row with id:'key_2'. Preferred label 'preferred\n" +
-        "label\n" +
-        "with\n" +
-        "linebreak' is not in the alt labels.");
+      expect(errorLogger.logWarning).toHaveBeenNthCalledWith(
+        1,
+        "Warning while importing Skill row with id:'key_2'. Preferred label 'preferred\n" +
+          "label\n" +
+          "with\n" +
+          "linebreak' is not in the alt labels."
+      );
       expect(errorLogger.logWarning).toHaveBeenNthCalledWith(2, "Failed to import Skill with skillId:key_6");
       expect(errorLogger.logWarning).toHaveBeenNthCalledWith(5, "Failed to import Skill from row:1 with importId:");
       expect(errorLogger.logWarning).toHaveBeenNthCalledWith(6, "Failed to import Skill from row:2 with importId:");

--- a/backend/src/import/removeGeneratedUUID/removeGeneratedUUID.test.ts
+++ b/backend/src/import/removeGeneratedUUID/removeGeneratedUUID.test.ts
@@ -37,6 +37,7 @@ function getNewModelInfoSpec(): INewModelInfoSpec {
       name: getTestString(LocaleAPISpecs.Constants.NAME_MAX_LENGTH),
       shortCode: getTestString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
     },
+    license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
     description: getTestString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
   };
 }

--- a/backend/src/modelInfo/index.integration.test.ts
+++ b/backend/src/modelInfo/index.integration.test.ts
@@ -32,6 +32,7 @@ async function createModelInDB() {
       shortCode: getTestString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
     },
     description: getTestString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+    license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
     UUIDHistory: [randomUUID()],
   });
 }
@@ -128,6 +129,7 @@ describe("Test for model handler with a DB", () => {
         name: getRandomString(LocaleAPISpecs.Constants.NAME_MAX_LENGTH),
         shortCode: getRandomString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
       },
+      license: getRandomString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
       description: getRandomString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
       UUIDHistory: [randomUUID()],
     };
@@ -158,6 +160,7 @@ describe("Test for model handler with a DB", () => {
         shortCode: getRandomString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
       },
       description: getRandomString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+      license: getRandomString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
       UUIDHistory: [randomUUID()],
     };
     const givenEvent = {

--- a/backend/src/modelInfo/index.test.ts
+++ b/backend/src/modelInfo/index.test.ts
@@ -76,6 +76,7 @@ describe("Test for model handler", () => {
           shortCode: getRandomString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
         },
         description: getRandomString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+        license: getRandomString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
         UUIDHistory: [randomUUID()],
       };
       const givenEvent = {
@@ -153,6 +154,7 @@ describe("Test for model handler", () => {
           name: "ZA",
           shortCode: "SA",
         },
+        license: "some random license",
         description: "some text",
         UUIDHistory: [randomUUID()],
       };

--- a/backend/src/modelInfo/index.ts
+++ b/backend/src/modelInfo/index.ts
@@ -105,6 +105,7 @@ class ModelController {
       name: payload.name,
       description: payload.description,
       locale: payload.locale,
+      license: payload.license,
       UUIDHistory: payload.UUIDHistory,
     };
 

--- a/backend/src/modelInfo/modelInfo.types.ts
+++ b/backend/src/modelInfo/modelInfo.types.ts
@@ -19,6 +19,7 @@ export interface IModelInfoDoc {
   locale: ILocale;
   description: string;
   UUID: string;
+  license: string;
   UUIDHistory: string[];
   released: boolean;
   releaseNotes: string;
@@ -64,7 +65,7 @@ export interface IModelInfo extends Omit<IModelInfoDoc, "importProcessState" | "
 /**
  * Describe how a new model info is created with the API
  */
-export type INewModelInfoSpec = Pick<IModelInfoDoc, "name" | "locale" | "description" | "UUIDHistory">;
+export type INewModelInfoSpec = Pick<IModelInfoDoc, "name" | "locale" | "license" | "description" | "UUIDHistory">;
 
 /**
  * Describes how a reference to a model is returned from the API

--- a/backend/src/modelInfo/modelInfoModel.test.ts
+++ b/backend/src/modelInfo/modelInfoModel.test.ts
@@ -46,6 +46,7 @@ describe("Test the definition of the ModelInfo Model", () => {
         },
         description: getTestString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
         released: false,
+        license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
         releaseNotes: getTestString(ModelInfoAPISpecs.Constants.RELEASE_NOTES_MAX_LENGTH),
         version: getTestString(ModelInfoAPISpecs.Constants.VERSION_MAX_LENGTH),
         importProcessState: getMockObjectId(2),
@@ -63,6 +64,7 @@ describe("Test the definition of the ModelInfo Model", () => {
           shortCode: getTestString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
         },
         description: "",
+        license: "",
         released: false,
         releaseNotes: "",
         importProcessState: getMockObjectId(2),
@@ -346,6 +348,34 @@ describe("Test the definition of the ModelInfo Model", () => {
       });
 
       testObjectIdField(() => ModelInfoModel, "importProcessState");
+    });
+
+    describe("Test validation of 'license'", () => {
+      test.each([
+        [CaseType.Failure, "undefined", undefined, "Path `{0}` is required."],
+        [CaseType.Failure, "null", null, "Path `{0}` is required."],
+        [
+          CaseType.Failure,
+          "Too long description",
+          getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH + 1),
+          `License must be at most ${ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH} chars long`,
+        ],
+        [CaseType.Success, "empty", "", undefined],
+        [CaseType.Success, "only whitespace characters", WHITESPACE, undefined],
+        [CaseType.Success, "one character", "a", undefined],
+        [CaseType.Success, "the longest", getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH), undefined],
+      ])(
+        "(%s) Validate 'license' when it is %s",
+        (caseType: CaseType, caseDescription, value, expectedFailureMessage) => {
+          assertCaseForProperty<IModelInfoDoc>({
+            model: ModelInfoModel,
+            propertyNames: "license",
+            caseType,
+            testValue: value,
+            expectedFailureMessage,
+          });
+        }
+      );
     });
 
     test("should have correct indexes", async () => {

--- a/backend/src/modelInfo/modelInfoModel.ts
+++ b/backend/src/modelInfo/modelInfoModel.ts
@@ -73,6 +73,14 @@ export function initializeSchemaAndModel(dbConnection: mongoose.Connection): mon
           `Release notes must be at most ${ModelInfoAPISpecs.Constants.RELEASE_NOTES_MAX_LENGTH} chars long`,
         ],
       },
+      license: {
+        type: String,
+        required: stringRequired("license"),
+        maxlength: [
+          ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH,
+          `License must be at most ${ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH} chars long`,
+        ],
+      },
       version: {
         type: String,
         required: stringRequired("version"),

--- a/backend/src/modelInfo/modelInfoRepository.test.ts
+++ b/backend/src/modelInfo/modelInfoRepository.test.ts
@@ -39,6 +39,7 @@ function getNewModelInfoSpec(): INewModelInfoSpec {
       name: getTestString(LocaleAPISpecs.Constants.NAME_MAX_LENGTH),
       shortCode: getTestString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
     },
+    license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
     description: getTestString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
   };
 }

--- a/backend/src/modelInfo/populateImportProcessStateOptions.test.ts
+++ b/backend/src/modelInfo/populateImportProcessStateOptions.test.ts
@@ -26,6 +26,7 @@ function getNewModelInfoSpec(): INewModelInfoSpec {
       shortCode: getTestString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
     },
     description: getTestString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+    license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
     UUIDHistory: [randomUUID()],
   };
 }

--- a/backend/src/modelInfo/testDataHelper.ts
+++ b/backend/src/modelInfo/testDataHelper.ts
@@ -19,6 +19,7 @@ export function getIModelInfoMockData(n: number = 1): IModelInfo {
       shortCode: getRandomString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
     },
     description: getRandomString(DESCRIPTION_MAX_LENGTH),
+    license: getRandomString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
     released: false,
     releaseNotes: getRandomString(ModelInfoAPISpecs.Constants.RELEASE_NOTES_MAX_LENGTH),
     version: getRandomString(ModelInfoAPISpecs.Constants.VERSION_MAX_LENGTH),

--- a/backend/src/modelInfo/transform.ts
+++ b/backend/src/modelInfo/transform.ts
@@ -17,6 +17,7 @@ export function transform(
     released: data.released,
     releaseNotes: data.releaseNotes,
     locale: data.locale,
+    license: data.license,
     path: `${baseURL}${Routes.MODELS_ROUTE}/${data.id}`,
     tabiyaPath: `${baseURL}${Routes.MODELS_ROUTE}/${data.UUID}`,
     exportProcessState: data.exportProcessState.map((exportProcessState) => ({

--- a/backend/test/integration/import.integration.test.ts
+++ b/backend/test/integration/import.integration.test.ts
@@ -22,6 +22,9 @@ import { parseSkillToSkillRelationFromFile } from "import/esco/skillToSkillRelat
 import { parseOccupationToSkillRelationFromFile } from "import/esco/occupationToSkillRelation/occupationToSkillRelationParser";
 import mongoose from "mongoose";
 import { countCSVRecords } from "import/esco/_test_utilities/countCSVRecords";
+import { getTestString } from "_test_utilities/specialCharacters";
+
+import ModelInfoAPISpecs from "api-specifications/modelInfo";
 
 enum DataTestType {
   SAMPLE = "SAMPLE",
@@ -101,6 +104,7 @@ describe("Test Import CSV files with an in-memory mongodb", () => {
         name: "CSVImport",
         description: "CSVImport",
         UUIDHistory: [randomUUID()],
+        license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
         locale: {
           name: "en",
           UUID: randomUUID(),

--- a/data-sets/csv/tabiya-esco-v1.1.1(fr)/LICENSE
+++ b/data-sets/csv/tabiya-esco-v1.1.1(fr)/LICENSE
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/data-sets/csv/tabiya-esco-v1.1.2(fr)/LICENSE
+++ b/data-sets/csv/tabiya-esco-v1.1.2(fr)/LICENSE
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/data-sets/csv/tabiya-esco-v1.1.2/LICENSE
+++ b/data-sets/csv/tabiya-esco-v1.1.2/LICENSE
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/data-sets/csv/tabiya-sample/LICENSE
+++ b/data-sets/csv/tabiya-sample/LICENSE
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/frontend/src/import/ImportModelDialog.tsx
+++ b/frontend/src/import/ImportModelDialog.tsx
@@ -34,6 +34,7 @@ export const DATA_TEST_ID = {
 export interface ImportData {
   name: string;
   description: string;
+  license: string;
   locale: LocaleAPISpecs.Types.Payload;
   selectedFiles: ImportFiles;
   UUIDHistory: string[];
@@ -68,6 +69,7 @@ const ImportModelDialog = (props: Readonly<ImportModelDialogProps>) => {
     description: "",
     locale: {} as any,
     selectedFiles: {},
+    license: "",
     UUIDHistory: [],
     isOriginalESCOModel: false,
   });
@@ -88,6 +90,10 @@ const ImportModelDialog = (props: Readonly<ImportModelDialogProps>) => {
 
   const handleUUIDHistoryChange = (newUUIDHistory: string[]) => {
     data.current.UUIDHistory = newUUIDHistory;
+  };
+
+  const handleLicenseChange = (newLicense: string) => {
+    data.current.license = newLicense;
   };
 
   const handleOriginalESCOChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -155,6 +161,7 @@ const ImportModelDialog = (props: Readonly<ImportModelDialogProps>) => {
           <ImportFilesSelection
             notifySelectedFileChange={handleSelectedFileChange}
             notifyUUIDHistoryChange={handleUUIDHistoryChange}
+            notifyOnLicenseChange={handleLicenseChange}
           />
         </Stack>
       </DialogContent>

--- a/frontend/src/import/__snapshots__/ImportModelDialog.test.tsx.snap
+++ b/frontend/src/import/__snapshots__/ImportModelDialog.test.tsx.snap
@@ -646,6 +646,52 @@ exports[`ImportModel dialog render tests should render the dialog visible 1`] = 
                   </div>
                 </div>
               </div>
+              <div
+                class="MuiBox-root css-8ghero"
+              >
+                <div
+                  data-filetype="LICENSE"
+                  data-testid="license-file-entry-16c54d56-b091-48ce-826a-c721b0c3643f"
+                >
+                  <div>
+                    <input
+                      accept="*"
+                      data-filetype="LICENSE"
+                      data-testid="license-file-input-16c54d56-b091-48ce-826a-c721b0c3643f"
+                      id="16c54d56-b091-48ce-826a-c721b0c3643f-license"
+                      style="display: none;"
+                      type="file"
+                    />
+                    <div
+                      aria-label="Add LICENSE file"
+                      class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-d8rrhm-MuiButtonBase-root-MuiChip-root"
+                      data-testid="license-select-file-button-16c54d56-b091-48ce-826a-c721b0c3643f"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorPrimary css-etbowg-MuiSvgIcon-root"
+                        data-testid="AddCircleOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                      >
+                        LICENSE
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/import/components/ImportFilesSelection.tsx
+++ b/frontend/src/import/components/ImportFilesSelection.tsx
@@ -3,10 +3,12 @@ import FileEntry from "./FileEntry";
 import ImportAPISpecs from "api-specifications/import";
 import { Box, FormLabel, Grid, Stack, useTheme } from "@mui/material";
 import ModelInfoFileEntry from "./ModelInfoFileEntry";
+import LicenseFileEntry from "./LicenseFileEntry";
 
 export interface ImportFilesSelectionProps {
   notifySelectedFileChange?: (fileType: ImportAPISpecs.Constants.ImportFileTypes, newFile: File | null) => void;
   notifyUUIDHistoryChange?: (newUUIDHistory: string[]) => void;
+  notifyOnLicenseChange?: (license: string) => void;
 }
 
 const uniqueId = "e60583c2-9ce5-47e0-bb8f-d2a4349dde15";
@@ -46,6 +48,16 @@ const ImportFilesSelection = (props: Readonly<ImportFilesSelectionProps>) => {
           }}
         >
           <ModelInfoFileEntry notifyUUIDHistoryChange={props.notifyUUIDHistoryChange} />
+        </Box>
+        <Box
+          key={`${uniqueId}-license`}
+          sx={{
+            flex: "0 0 auto",
+            marginBottom: (theme) => theme.tabiyaSpacing.sm,
+            marginRight: (theme) => theme.tabiyaRounding.sm,
+          }}
+        >
+          <LicenseFileEntry notifyOnLicenseChange={props.notifyOnLicenseChange} />
         </Box>
       </Grid>
     </Stack>

--- a/frontend/src/import/components/LicenseFileEntry.test.tsx
+++ b/frontend/src/import/components/LicenseFileEntry.test.tsx
@@ -1,0 +1,243 @@
+// mute the console
+import "src/_test_utilities/consoleMock";
+
+import { useSnackbar } from "src/theme/SnackbarProvider/SnackbarProvider";
+import { clickDebouncedButton } from "src/_test_utilities/userEventFakeTimer";
+import { fireEvent, render, screen, waitFor } from "src/_test_utilities/test-utils";
+import LicenseFileEntry, { DATA_TEST_ID, licenseFileType, licenseFileTypeName } from "./LicenseFileEntry";
+
+// mock the snackbar
+jest.mock("src/theme/SnackbarProvider/SnackbarProvider", () => {
+  const actual = jest.requireActual("src/theme/SnackbarProvider/SnackbarProvider");
+  return {
+    ...actual,
+    __esModule: true,
+    useSnackbar: jest.fn().mockReturnValue({
+      enqueueSnackbar: jest.fn(),
+      closeSnackbar: jest.fn(),
+    }),
+  };
+});
+
+describe("LicenseFileEntry render tests", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Should render the licenseFileEntry component", () => {
+    // When LicenseFileEntry is rendered
+    render(<LicenseFileEntry />);
+
+    // THEN expect no errors or warning to have occurred
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+    // AND the component to be rendered
+    const fileEntry = screen.getByTestId(DATA_TEST_ID.FILE_ENTRY);
+    expect(fileEntry).toBeInTheDocument();
+    expect(fileEntry).toMatchSnapshot();
+    // AND to have the correct file type
+    expect(fileEntry).toHaveAttribute("data-filetype");
+
+    // AND expect file input's to have no files
+    const fileInput: HTMLInputElement = screen.getByTestId(DATA_TEST_ID.FILE_INPUT);
+    expect(fileInput.files).toHaveLength(0);
+    // AND expect file input to have the file type
+    expect(fileInput).toHaveAttribute("data-filetype", licenseFileType);
+
+    // AND expect file trigger fab to be in the document
+    const selectFileButton = screen.getByTestId(DATA_TEST_ID.SELECT_FILE_BUTTON);
+    expect(selectFileButton).toBeInTheDocument();
+
+    // AND expect file remover fab to not be in the document
+    const fileRemoverButton = screen.queryByTestId(DATA_TEST_ID.REMOVE_SELECTED_FILE_BUTTON);
+    expect(fileRemoverButton).not.toBeInTheDocument();
+
+    // AND expect the SELECT_FILE_BUTTON to have the correct file type name
+    expect(selectFileButton.textContent).toBe(licenseFileTypeName);
+  });
+});
+
+describe("LicenseFileEntry action tests", () => {
+  it("should select file", async () => {
+    // GIVEN some file
+    const givenFile = new File([], licenseFileTypeName, { type: "txt" });
+    givenFile.text = jest.fn().mockResolvedValue("foo license");
+
+    // When LicenseFileEntry is rendered
+    render(<LicenseFileEntry />);
+    // AND fileInput value is changed
+    const fileInput: HTMLInputElement = screen.getByTestId(DATA_TEST_ID.FILE_INPUT);
+    fireEvent.change(fileInput, { target: { files: [givenFile] } });
+
+    // THEN expect file input to have 1 file
+    expect(fileInput.files).toHaveLength(1);
+
+    // AND expect file trigger fab to not be in the document
+    const selectFileButton = screen.queryByTestId(DATA_TEST_ID.SELECT_FILE_BUTTON);
+    expect(selectFileButton).not.toBeInTheDocument();
+
+    // AND expect file remover fab to be in the document
+    const fileRemoverFab = screen.queryByTestId(DATA_TEST_ID.REMOVE_SELECTED_FILE_BUTTON);
+    expect(fileRemoverFab).toBeInTheDocument();
+  });
+
+  it("should remove selected file", async () => {
+    // GIVEN some file
+
+    const givenFile = new File([], licenseFileTypeName);
+    givenFile.text = jest.fn().mockResolvedValue("foo license");
+
+    // When LicenseFileEntry is rendered
+    render(<LicenseFileEntry />);
+
+    // AND fileInput value has changed
+    let fileInput: HTMLInputElement = screen.getByTestId(DATA_TEST_ID.FILE_INPUT);
+    fireEvent.change(fileInput, { target: { files: [givenFile] } });
+    expect(fileInput.files).toHaveLength(1);
+
+    // WHEN fileRemoverFab is clicked
+    const fileRemoverFab = screen.getByTestId(DATA_TEST_ID.REMOVE_SELECTED_FILE_BUTTON);
+    await clickDebouncedButton(fileRemoverFab);
+
+    // THEN expect file input to have an empty files
+    // wait for the component's state to update
+    await waitFor(() => {
+      fileInput = screen.getByTestId(DATA_TEST_ID.FILE_INPUT);
+    }, {});
+
+    expect(fileInput.files).toHaveLength(0);
+    // AND expect file trigger fab to be in the document
+    const selectFileButton = screen.getByTestId(DATA_TEST_ID.SELECT_FILE_BUTTON);
+    expect(selectFileButton).toBeInTheDocument();
+  });
+
+  it("should correctly notify the notifyUUIDHistoryChange handler when file is selected", async () => {
+    // GIVEN some file
+    const givenLicense = "foo license";
+    const givenFile = new File([], licenseFileTypeName);
+    givenFile.text = jest.fn().mockResolvedValue(givenLicense);
+
+    // AND a notification handler
+    const givenMockNotification = jest.fn();
+
+    // When LicenseFileEntry is rendered
+    render(<LicenseFileEntry notifyOnLicenseChange={givenMockNotification} />);
+    // AND a file is chosen
+    const fileInput = screen.getByTestId(DATA_TEST_ID.FILE_INPUT);
+    fireEvent.change(fileInput, { target: { files: [givenFile] } });
+
+    // THEN expect the notification handler to have been called with the given filetype and file
+    await waitFor(() => {
+      expect(givenMockNotification).toHaveBeenCalledWith(givenLicense);
+    });
+  });
+
+  it("should correctly notify the notifyOnLicenseChange handler when file is removed", async () => {
+    // GIVEN some file
+    const givenLicenseContent = "foo license";
+    const givenFile = new File([new Blob(["foo bar "])], licenseFileTypeName);
+    File.prototype.text = jest.fn().mockResolvedValue(givenLicenseContent);
+
+    // AND a notification handler
+    const givenMockNotification = jest.fn();
+
+    // When LicenseFileEntry is rendered
+    render(<LicenseFileEntry notifyOnLicenseChange={givenMockNotification} />);
+    // AND the given file has been selected
+
+    let fileInput: HTMLInputElement = screen.getByTestId(DATA_TEST_ID.FILE_INPUT);
+    fireEvent.change(fileInput, { target: { files: [givenFile] } });
+
+    expect(fileInput.files).toHaveLength(1);
+
+    // THEN expect notificationHandler to have been called with givenFileType and null,
+    await waitFor(() => {
+      expect(givenMockNotification).toHaveBeenNthCalledWith(1, givenLicenseContent);
+    });
+
+    // WHEN the file is removed.
+    // AND the remove selected file button is clicked
+    const fileRemoverFab = screen.getByTestId(DATA_TEST_ID.REMOVE_SELECTED_FILE_BUTTON);
+
+    // wait for the component's state to update
+    await clickDebouncedButton(fileRemoverFab);
+
+    // THEN expect notificationHandler to have been called with givenFileType and null,
+    await waitFor(() => {
+      expect(givenMockNotification).toHaveBeenNthCalledWith(2, "");
+    });
+  });
+
+  it("should handle file changes even if notifyUUIDHistoryChange handler is not set", async () => {
+    // GIVEN some file
+    const givenLicenseContent = "foo license";
+    const givenAFile = new File([], licenseFileTypeName);
+    File.prototype.text = jest.fn().mockResolvedValue(givenLicenseContent);
+
+    // When LicenseFileEntry is rendered without a notification handler
+    render(<LicenseFileEntry />);
+    // AND fileInput value has changed
+    let fileInput: HTMLInputElement = screen.getByTestId(DATA_TEST_ID.FILE_INPUT);
+    fireEvent.change(fileInput, { target: { files: [givenAFile] } });
+
+    // THEN expect file input to have 1 files
+    expect(fileInput.files).toHaveLength(1);
+
+    // AND expect the fileRemoverButton to be in the document
+    const fileRemoverButton = screen.getByTestId(DATA_TEST_ID.REMOVE_SELECTED_FILE_BUTTON);
+    expect(fileRemoverButton).toBeInTheDocument();
+  });
+
+  it("should show a snackbar when the file is not parsed correctly", async () => {
+    // GIVEN some file
+    const givenLicenseContent = "foo license";
+    const givenFile = new File([], licenseFileTypeName);
+    File.prototype.text = jest.fn().mockResolvedValue(givenLicenseContent);
+
+    // AND a notification handler
+    const givenMockNotification = jest.fn();
+
+    // AND file parsing throws an error
+    const givenError = "Error parsing file";
+    givenFile.text = jest.fn().mockRejectedValue("Error parsing file");
+
+    // WHEN LicenseFileEntry is rendered
+    render(<LicenseFileEntry notifyOnLicenseChange={givenMockNotification} />);
+
+    // AND a file is chosen
+    const fileInput = screen.getByTestId(DATA_TEST_ID.FILE_INPUT);
+    fireEvent.change(fileInput, { target: { files: [givenFile] } });
+
+    // THEN expect the notification handler not to have been called
+    expect(givenMockNotification).not.toHaveBeenCalled();
+
+    // AND expect the error to have been logged to the console
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalledWith(givenError);
+    });
+
+    // THEN expect a snackbar to have been shown
+    const { enqueueSnackbar } = useSnackbar();
+    expect(enqueueSnackbar).toHaveBeenCalledWith(
+      `Error parsing file: ${givenFile.name}. Please review the file and try again.`,
+      { variant: "error" }
+    );
+  });
+
+  it("should open the file input when the select file button is clicked", async () => {
+    // GIVEN the component is rendered  with a notification handler
+    const givenMockNotification = jest.fn();
+    render(<LicenseFileEntry notifyOnLicenseChange={givenMockNotification} />);
+
+    // AND We have a file input in the content
+    const fileInput = screen.getByTestId(DATA_TEST_ID.FILE_INPUT);
+    const fileInputClickSpy = jest.spyOn(fileInput, 'click'); // Spy on the click method
+
+    // WHEN the select file button is clicked
+    const selectFileButton = screen.getByTestId(DATA_TEST_ID.SELECT_FILE_BUTTON);
+    fireEvent.click(selectFileButton);
+
+    // THEN the file input should be clicked
+    expect(fileInputClickSpy).toHaveBeenCalled();
+  })
+});

--- a/frontend/src/import/components/LicenseFileEntry.tsx
+++ b/frontend/src/import/components/LicenseFileEntry.tsx
@@ -1,0 +1,102 @@
+import React, { ChangeEvent, useState } from "react";
+import { Chip } from "@mui/material";
+import debounce from "lodash.debounce";
+import { DEBOUNCE_INTERVAL } from "./debouncing";
+import { AddCircleOutlined, RemoveCircleOutlined } from "@mui/icons-material";
+import { useSnackbar } from "src/theme/SnackbarProvider/SnackbarProvider";
+
+export interface LicenseFileEntryProps {
+  notifyOnLicenseChange?: (license: string) => void;
+}
+
+const uniqueId = "16c54d56-b091-48ce-826a-c721b0c3643f";
+
+export const DATA_TEST_ID = {
+  FILE_ENTRY: `license-file-entry-${uniqueId}`,
+  FILE_INPUT: `license-file-input-${uniqueId}`,
+  SELECT_FILE_BUTTON: `license-select-file-button-${uniqueId}`,
+  REMOVE_SELECTED_FILE_BUTTON: `license-remove-selected-file-button-${uniqueId}`,
+};
+export const licenseFileType = "LICENSE";
+export const licenseFileTypeName = "LICENSE";
+
+/**
+ * Represent a file entry of the license type and a selected file
+ * The data-filetype attribute is used to identify the file type
+ * @constructor
+ */
+
+export const LicenseFileEntry = (props: Readonly<LicenseFileEntryProps>) => {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const { enqueueSnackbar } = useSnackbar();
+
+  const fileChangedHandler = async (e: ChangeEvent<HTMLInputElement>) => {
+    const newFile: File = e.target?.files![0];
+    // if some file is available, update the selected file
+    await updateSelectedFile(newFile);
+  };
+
+  const fileRemovedHandler = async () => {
+    await updateSelectedFile(null);
+  };
+
+  const updateSelectedFile = async (file: File | null) => {
+    setSelectedFile(file); // update the selected file
+
+    try {
+      // notify the parent component if it has provided handler
+      const fileContent = file ? await file.text() : "";
+
+      if (props.notifyOnLicenseChange && fileContent && file) {
+        props.notifyOnLicenseChange(fileContent);
+      } else if (props.notifyOnLicenseChange) {
+        props.notifyOnLicenseChange("");
+      }
+    } catch (e) {
+      console.error(e);
+      enqueueSnackbar(`Error parsing file: ${licenseFileTypeName}. Please review the file and try again.`, {
+        variant: "error",
+      });
+    }
+  };
+
+  const debounceFileRemoveHandler = debounce(fileRemovedHandler, DEBOUNCE_INTERVAL);
+
+  return (
+    <div data-filetype={licenseFileType} data-testid={DATA_TEST_ID.FILE_ENTRY}>
+      {selectedFile ? (
+        <Chip
+          color="secondary"
+          aria-label={`Remove license file`}
+          data-testid={DATA_TEST_ID.REMOVE_SELECTED_FILE_BUTTON}
+          onClick={debounceFileRemoveHandler}
+          icon={<RemoveCircleOutlined />}
+          label={`${licenseFileTypeName}: ${selectedFile.name}`}
+        />
+      ) : (
+        <div>
+          <input
+            id={`${uniqueId}-license`}
+            type="file"
+            style={{ display: "none" }}
+            accept="*"
+            data-testid={DATA_TEST_ID.FILE_INPUT}
+            onChange={fileChangedHandler}
+            data-filetype={licenseFileType}
+          />
+          <Chip
+            color="primary"
+            aria-label={`Add ${licenseFileType} file`}
+            data-testid={DATA_TEST_ID.SELECT_FILE_BUTTON}
+            onClick={() => {
+              document.getElementById(`${uniqueId}-license`)!.click()
+            }}
+            icon={<AddCircleOutlined />}
+            label={licenseFileTypeName}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+export default LicenseFileEntry;

--- a/frontend/src/import/components/__snapshots__/ImportFilesSelection.test.tsx.snap
+++ b/frontend/src/import/components/__snapshots__/ImportFilesSelection.test.tsx.snap
@@ -154,6 +154,52 @@ exports[`ImportFilesSelection render tests should render default state 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="MuiBox-root css-8ghero"
+    >
+      <div
+        data-filetype="LICENSE"
+        data-testid="license-file-entry-16c54d56-b091-48ce-826a-c721b0c3643f"
+      >
+        <div>
+          <input
+            accept="*"
+            data-filetype="LICENSE"
+            data-testid="license-file-input-16c54d56-b091-48ce-826a-c721b0c3643f"
+            id="16c54d56-b091-48ce-826a-c721b0c3643f-license"
+            style="display: none;"
+            type="file"
+          />
+          <div
+            aria-label="Add LICENSE file"
+            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-d8rrhm-MuiButtonBase-root-MuiChip-root"
+            data-testid="license-select-file-button-16c54d56-b091-48ce-826a-c721b0c3643f"
+            role="button"
+            tabindex="0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorPrimary css-etbowg-MuiSvgIcon-root"
+              data-testid="AddCircleOutlinedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
+              />
+            </svg>
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+            >
+              LICENSE
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/frontend/src/import/components/__snapshots__/LicenseFileEntry.test.tsx.snap
+++ b/frontend/src/import/components/__snapshots__/LicenseFileEntry.test.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LicenseFileEntry render tests Should render the licenseFileEntry component 1`] = `
+<div
+  data-filetype="LICENSE"
+  data-testid="license-file-entry-16c54d56-b091-48ce-826a-c721b0c3643f"
+>
+  <div>
+    <input
+      accept="*"
+      data-filetype="LICENSE"
+      data-testid="license-file-input-16c54d56-b091-48ce-826a-c721b0c3643f"
+      id="16c54d56-b091-48ce-826a-c721b0c3643f-license"
+      style="display: none;"
+      type="file"
+    />
+    <div
+      aria-label="Add LICENSE file"
+      class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-d8rrhm-MuiButtonBase-root-MuiChip-root"
+      data-testid="license-select-file-button-16c54d56-b091-48ce-826a-c721b0c3643f"
+      role="button"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorPrimary css-etbowg-MuiSvgIcon-root"
+        data-testid="AddCircleOutlinedIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
+        />
+      </svg>
+      <span
+        class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+      >
+        LICENSE
+      </span>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/import/importDirector.service.test.ts
+++ b/frontend/src/import/importDirector.service.test.ts
@@ -71,9 +71,10 @@ describe("Test the import director service", () => {
     const uploadService = new UploadService();
     const importService = new ImportService("foo");
 
-    // AND a name, description, locale and files
+    // AND a name, description, license, locale and files
     const givenName = getTestString(ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH);
     const givenDescription = getTestString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH);
+    const givenLicense = getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH);
     const givenLocale = {
       name: getTestString(LocaleAPISpecs.Constants.NAME_MAX_LENGTH),
       UUID: randomUUID(),
@@ -96,6 +97,7 @@ describe("Test the import director service", () => {
     const actualModel = await manager.directImport(
       givenName,
       givenDescription,
+      givenLicense,
       givenLocale,
       givenFiles,
       givenUUIDHistory,
@@ -110,6 +112,7 @@ describe("Test the import director service", () => {
       name: givenName,
       description: givenDescription,
       locale: givenLocale,
+      license: givenLicense,
       UUIDHistory: givenUUIDHistory,
     });
 

--- a/frontend/src/import/importDirector.service.ts
+++ b/frontend/src/import/importDirector.service.ts
@@ -17,6 +17,7 @@ export default class ImportDirectorService {
   async directImport(
     name: string,
     description: string,
+    license: string,
     locale: LocaleAPISpecs.Types.Payload,
     files: ImportFiles,
     UUIDHistory: string[],
@@ -25,7 +26,7 @@ export default class ImportDirectorService {
     const modelService = new ModelInfoService(this.apiServerUrl);
     const presignedService = new PresignedService(this.apiServerUrl);
     const [newModel, presigned] = await Promise.all([
-      modelService.createModel({ name, description, locale, UUIDHistory }),
+      modelService.createModel({ name, description, locale, UUIDHistory, license }),
       presignedService.getPresignedPost(),
     ]);
 

--- a/frontend/src/modelInfo/_test_utilities/mockModelInfoPayload.ts
+++ b/frontend/src/modelInfo/_test_utilities/mockModelInfoPayload.ts
@@ -71,6 +71,7 @@ export namespace GET {
         released: i % 2 === 0, // 50% chance of released
         releaseNotes: getRandomLorem(ModelInfoAPISpecs.Constants.RELEASE_NOTES_MAX_LENGTH),
         version: getRandomLorem(ModelInfoAPISpecs.Constants.VERSION_MAX_LENGTH),
+        license: getRandomString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
         path: faker.internet.url(),
         tabiyaPath: faker.internet.url(),
         exportProcessState: [
@@ -138,6 +139,7 @@ export function getRandomModelInfo(_id: number): PayloadItem<ModelInfoAPISpecs.T
       shortCode: getTestString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
     },
     description: getTestString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+    license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
     released: _id % 2 === 0,
     releaseNotes: getTestString(ModelInfoAPISpecs.Constants.RELEASE_NOTES_MAX_LENGTH),
     version: getTestString(ModelInfoAPISpecs.Constants.VERSION_MAX_LENGTH),

--- a/frontend/src/modelInfo/modelInfo.service.test.ts
+++ b/frontend/src/modelInfo/modelInfo.service.test.ts
@@ -18,6 +18,7 @@ function getNewModelSpecMockData(): INewModelSpecification {
   return {
     name: getTestString(ModelInfoAPISpecs.Constants.NAME_MAX_LENGTH),
     description: getTestString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+    license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
     locale: {
       name: getTestString(LocaleAPISpecs.Constants.NAME_MAX_LENGTH),
       shortCode: getTestString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),

--- a/frontend/src/modelInfo/modelInfoTypes.ts
+++ b/frontend/src/modelInfo/modelInfoTypes.ts
@@ -52,6 +52,7 @@ export namespace ModelInfoTypes {
     name: string;
     locale: Locale;
     description: string;
+    license: string;
     path: string;
     tabiyaPath: string;
     exportProcessState: ExportProcessState[];

--- a/frontend/src/modeldirectory/ModelDirectory.test.tsx
+++ b/frontend/src/modeldirectory/ModelDirectory.test.tsx
@@ -198,6 +198,9 @@ function getTestImportData(): ImportData {
     }
   );
 
+  // model license
+  const license = "MIT";
+
   //The locale
   const locale: LocaleAPISpecs.Types.Payload = {
     UUID: "8e763c32-4c21-449c-94ee-7ddeb379369a",
@@ -208,7 +211,7 @@ function getTestImportData(): ImportData {
   const UUIDHistory = [randomUUID()];
   // and the isOriginalESCOModel
   const isOriginalESCOModel = false;
-  return { name, description, locale, selectedFiles, UUIDHistory, isOriginalESCOModel };
+  return { name, description, locale, license, selectedFiles, UUIDHistory, isOriginalESCOModel };
 }
 
 describe("ModelDirectory", () => {
@@ -1040,6 +1043,7 @@ describe("ModelDirectory", () => {
       expect(ImportDirectorService.prototype.directImport).toHaveBeenCalledWith(
         givenImportData.name,
         givenImportData.description,
+        givenImportData.license,
         givenImportData.locale,
         givenImportData.selectedFiles,
         givenImportData.UUIDHistory,
@@ -1126,6 +1130,7 @@ describe("ModelDirectory", () => {
       expect(ImportDirectorService.prototype.directImport).toHaveBeenCalledWith(
         givenImportData.name,
         givenImportData.description,
+        givenImportData.license,
         givenImportData.locale,
         givenImportData.selectedFiles,
         givenImportData.UUIDHistory,
@@ -1191,6 +1196,7 @@ describe("ModelDirectory", () => {
       expect(ImportDirectorService.prototype.directImport).toHaveBeenCalledWith(
         givenImportData.name,
         givenImportData.description,
+        givenImportData.license,
         givenImportData.locale,
         givenImportData.selectedFiles,
         givenImportData.UUIDHistory,

--- a/frontend/src/modeldirectory/ModelDirectory.tsx
+++ b/frontend/src/modeldirectory/ModelDirectory.tsx
@@ -159,6 +159,7 @@ const ModelDirectory = () => {
         const newModel = await importDirectorService.directImport(
           importData.name,
           importData.description,
+          importData.license,
           importData.locale,
           importData.selectedFiles,
           importData.UUIDHistory,

--- a/frontend/src/modeldirectory/components/ModelProperties/ModelPropertiesDrawer.test.tsx
+++ b/frontend/src/modeldirectory/components/ModelProperties/ModelPropertiesDrawer.test.tsx
@@ -43,6 +43,7 @@ jest.mock("./components/ModelPropertiesContent/ModelPropertiesContent", () => {
 const testModel: ModelInfoTypes.ModelInfo = {
   name: "foo",
   description: "",
+  license: "",
   id: "",
   UUID: "",
   modelHistory: [],

--- a/frontend/src/modeldirectory/components/ModelProperties/components/ModelPropertiesContent/components/ModelPropertiesVersion/ModelPropertiesVersion.test.tsx
+++ b/frontend/src/modeldirectory/components/ModelProperties/components/ModelPropertiesContent/components/ModelPropertiesVersion/ModelPropertiesVersion.test.tsx
@@ -137,6 +137,19 @@ describe("ModelPropertiesVersion", () => {
       },
       {}
     );
+    // AND the release notes property to be shown
+    const actualLicense = screen.getByTestId(DATA_TEST_ID.MODEL_PROPERTIES_LICENSE);
+    expect(actualLicense).toBeInTheDocument();
+    // AND TextPropertyField component to be called with the correct props for the 'release notes'
+    expect(MarkdownPropertyField).toHaveBeenCalledWith(
+      {
+        label: FIELD_LABEL_TEXT.LABLE_LICENSE,
+        text: givenModel.license,
+        "data-testid": DATA_TEST_ID.MODEL_PROPERTIES_LICENSE,
+        fieldId: FIELD_ID.LICENSE,
+      },
+      {}
+    );
     // AND to match the snapshot
     expect(modelPropertiesVersionContainer).toMatchSnapshot();
   });
@@ -156,6 +169,7 @@ describe("ModelPropertiesVersion", () => {
         DATA_TEST_ID.MODEL_PROPERTIES_VERSION,
         DATA_TEST_ID.MODEL_PROPERTIES_RELEASED_STATUS,
         DATA_TEST_ID.MODEL_PROPERTIES_RELEASE_NOTES,
+        DATA_TEST_ID.MODEL_PROPERTIES_LICENSE,
       ],
     })
   );

--- a/frontend/src/modeldirectory/components/ModelProperties/components/ModelPropertiesContent/components/ModelPropertiesVersion/ModelPropertiesVersion.tsx
+++ b/frontend/src/modeldirectory/components/ModelProperties/components/ModelPropertiesContent/components/ModelPropertiesVersion/ModelPropertiesVersion.tsx
@@ -20,6 +20,7 @@ export const DATA_TEST_ID = {
   MODEL_PROPERTIES_VERSION: `model-properties-version-${uniqueId}`,
   MODEL_PROPERTIES_RELEASED_STATUS: `model-properties-released-status-${uniqueId}`,
   MODEL_PROPERTIES_RELEASE_NOTES: `model-properties-release-notes-${uniqueId}`,
+  MODEL_PROPERTIES_LICENSE: `model-properties-license-${uniqueId}`,
 };
 
 export const FIELD_ID = {
@@ -29,6 +30,7 @@ export const FIELD_ID = {
   VERSION: `version-${uniqueId}`,
   RELEASED_STATUS: `released-status-${uniqueId}`,
   RELEASE_NOTES: `release-notes-${uniqueId}`,
+  LICENSE: `license-${uniqueId}`,
 };
 
 export const FIELD_LABEL_TEXT = {
@@ -37,6 +39,7 @@ export const FIELD_LABEL_TEXT = {
   LABEL_PATH: "Path",
   LABEL_VERSION: "Version",
   LABEL_RELEASE_NOTES: "Release Notes",
+  LABLE_LICENSE: "License",
 };
 
 /**
@@ -97,6 +100,12 @@ const ModelPropertiesVersion: React.FC<ModelPropertiesVersionProps> = (
         text={props.model.releaseNotes}
         data-testid={DATA_TEST_ID.MODEL_PROPERTIES_RELEASE_NOTES}
         fieldId={FIELD_ID.RELEASE_NOTES}
+      />
+      <MarkdownPropertyField
+        label={FIELD_LABEL_TEXT.LABLE_LICENSE}
+        text={props.model.license}
+        data-testid={DATA_TEST_ID.MODEL_PROPERTIES_LICENSE}
+        fieldId={FIELD_ID.LICENSE}
       />
     </Box>
   );

--- a/frontend/src/modeldirectory/components/ModelProperties/components/ModelPropertiesContent/components/ModelPropertiesVersion/__snapshots__/ModelPropertiesVersion.test.tsx.snap
+++ b/frontend/src/modeldirectory/components/ModelProperties/components/ModelPropertiesContent/components/ModelPropertiesVersion/__snapshots__/ModelPropertiesVersion.test.tsx.snap
@@ -41,5 +41,11 @@ exports[`ModelPropertiesVersion should render correctly with the provided model 
   >
     Markdown Property Field Mock
   </div>
+  <div
+    data-testid="model-properties-license-8d3b0caa-95e2-4f11-a98c-054208e72438"
+    id="license-8d3b0caa-95e2-4f11-a98c-054208e72438"
+  >
+    Markdown Property Field Mock
+  </div>
 </div>
 `;

--- a/frontend/src/modeldirectory/components/ModelsTable/_test_utilities/mockModelData.ts
+++ b/frontend/src/modeldirectory/components/ModelsTable/_test_utilities/mockModelData.ts
@@ -48,6 +48,7 @@ export function getArrayOfFakeModels(count: number): ModelInfoTypes.ModelInfo[] 
         i % 2 === 0
           ? getRandomLorem(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH)
           : getRandomLorem(CELL_MAX_LENGTH / 2), // 50% chance of long description
+      license: faker.lorem.text().substring(0, ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
       released: i % 2 === 0, // 50% chance of released
       releaseNotes: faker.lorem.text().substring(0, ModelInfoAPISpecs.Constants.RELEASE_NOTES_MAX_LENGTH),
       version: faker.system.semver().substring(0, ModelInfoAPISpecs.Constants.VERSION_MAX_LENGTH),
@@ -88,6 +89,7 @@ export function getArrayOfFakeModelsMaxLength(count: number): ModelInfoTypes.Mod
         shortCode: getRandomLorem(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
       },
       description: getRandomLorem(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+      license: getRandomLorem(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
       released: i % 2 === 0, // 50% chance of released
       releaseNotes: getRandomLorem(ModelInfoAPISpecs.Constants.RELEASE_NOTES_MAX_LENGTH),
       version: getRandomLorem(ModelInfoAPISpecs.Constants.VERSION_MAX_LENGTH),
@@ -129,6 +131,7 @@ export function getArrayOfRandomModelsMaxLength(number: number): ModelInfoTypes.
         shortCode: getTestString(LocaleAPISpecs.Constants.LOCALE_SHORTCODE_MAX_LENGTH),
       },
       description: getTestString(ModelInfoAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+      license: getTestString(ModelInfoAPISpecs.Constants.LICENSE_MAX_LENGTH),
       released: i % 2 === 0,
       releaseNotes: getTestString(ModelInfoAPISpecs.Constants.RELEASE_NOTES_MAX_LENGTH),
       version: getTestString(ModelInfoAPISpecs.Constants.VERSION_MAX_LENGTH),
@@ -156,6 +159,7 @@ export const fakeModel: ModelInfoTypes.ModelInfo = {
     },
   ],
   description: "aw j zt   agrkasl dy ogtimpsauwumu l utrovthao syertm beawpxluhyudgzbbm",
+  license: "Praesentium quia",
   id: "000000000000000000000001",
   importProcessState: {
     id: "000000000000000000000001",

--- a/frontend/src/theme/PropertyFieldLayout/MarkdownPropertyField/MarkdownPropertyField.test.tsx
+++ b/frontend/src/theme/PropertyFieldLayout/MarkdownPropertyField/MarkdownPropertyField.test.tsx
@@ -29,9 +29,7 @@ jest.mock("src/theme/PropertyFieldLayout/PropertyFieldLayout", () => {
 jest.mock("react-markdown", () => {
   return jest.fn().mockImplementation((props) => {
     const { remarkPlugins, urlTransform, components, ...rest } = props;
-    return (
-      <span {...rest} />
-    );
+    return <span {...rest} />;
   });
 });
 


### PR DESCRIPTION
1. adjust POST /modelinfo API to accept license
2. adjust GET /modelinfo to return licence to the frontend
3. adjust export API to save license in its own file.
4. add a new button on the frontend to upload a license file
5. show license on model details.
6. add LICENSE file to existing csv models for `Attribution 4.0 International`