### PR TITLE
fix(security): Move all inputs.* expressions from inside run: blocks …

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -67,13 +67,19 @@ jobs:
       - name: Build env.js file
         # we are basically creating a js file with the passed env variables
         # that can be executed in the client browser when the js file is loaded
+        env:
+          INPUT_BACKEND_URL: ${{ inputs.backend-url }}
+          INPUT_LOCALES_URL: ${{ inputs.locales-url }}
+          INPUT_AUTH_URL: ${{ inputs.auth-url }}
+          INPUT_COGNITO_CLIENT_ID: ${{ inputs.cognito-client-id }}
+          INPUT_COGNITO_CLIENT_SECRET: ${{ inputs.cognito-client-secret }}
         run: |
           echo "window.tabiyaConfig = {" > frontend/build/data/env.js
-          echo "\"BACKEND_URL\": btoa(\"${{ inputs.backend-url }}\")," >> frontend/build/data/env.js
-          echo "\"LOCALES_URL\": btoa(\"${{ inputs.locales-url }}\")," >> frontend/build/data/env.js
-          echo "\"AUTH_URL\": btoa(\"${{ inputs.auth-url }}\")," >> frontend/build/data/env.js
-          echo "\"COGNITO_CLIENT_ID\": btoa(\"${{ inputs.cognito-client-id }}\")," >> frontend/build/data/env.js
-          echo "\"COGNITO_CLIENT_SECRET\": btoa(\"${{ inputs.cognito-client-secret }}\")" >> frontend/build/data/env.js
+          echo "\"BACKEND_URL\": btoa(\"$INPUT_BACKEND_URL\")," >> frontend/build/data/env.js
+          echo "\"LOCALES_URL\": btoa(\"$INPUT_LOCALES_URL\")," >> frontend/build/data/env.js
+          echo "\"AUTH_URL\": btoa(\"$INPUT_AUTH_URL\")," >> frontend/build/data/env.js
+          echo "\"COGNITO_CLIENT_ID\": btoa(\"$INPUT_COGNITO_CLIENT_ID\")," >> frontend/build/data/env.js
+          echo "\"COGNITO_CLIENT_SECRET\": btoa(\"$INPUT_COGNITO_CLIENT_SECRET\")" >> frontend/build/data/env.js
           echo "};" >> frontend/build/data/env.js
           cat frontend/build/data/env.js
       - name: Deploy frontend

--- a/.github/workflows/smoke-test-version.yml
+++ b/.github/workflows/smoke-test-version.yml
@@ -41,9 +41,10 @@ jobs:
         working-directory: ${{ inputs.component }}
       - id: smoke-test
         shell: bash
+        env:
+          EXPECTED_VERSION_INFO: ${{ inputs.expected-version-info }}
+          E2E_BASE_URL: ${{ inputs.component-url }}
+          E2E_RESOURCES_BASE_URL: ${{ inputs.resources-base-url }}
         run: |
-          export EXPECTED_VERSION_INFO='${{ inputs.expected-version-info }}'
-          export E2E_BASE_URL=${{ inputs.component-url }}
-          export E2E_RESOURCES_BASE_URL=${{ inputs.resources-base-url }}
           yarn run test:smoke
         working-directory: ${{ inputs.component }}


### PR DESCRIPTION
…into env: blocks

-  GitHub Actions evaluates ${{ inputs.* }} expressions before the shell runs, meaning a malicious value like `curl attacker.com` would be interpolated directly into the shell script enabling script injection. [pulumi up]