### PR TITLE
feat(api-spec): implement PATCH and PUT API specifications for occupations

### DIFF
--- a/api-specifications/src/error/types.ts
+++ b/api-specifications/src/error/types.ts
@@ -67,6 +67,12 @@ namespace ErrorTypes {
       | OccupationAPI.Occupation.Parent.GET.Errors.Status500.ErrorCodes
       | OccupationAPI.Occupation.Children.GET.Errors.Status500.ErrorCodes
       | OccupationAPI.Occupation.Skills.GET.Errors.Status500.ErrorCodes
+      | OccupationAPI.Occupation.PUT.Errors.Status400.ErrorCodes
+      | OccupationAPI.Occupation.PUT.Errors.Status404.ErrorCodes
+      | OccupationAPI.Occupation.PUT.Errors.Status500.ErrorCodes
+      | OccupationAPI.Occupation.PATCH.Errors.Status400.ErrorCodes
+      | OccupationAPI.Occupation.PATCH.Errors.Status404.ErrorCodes
+      | OccupationAPI.Occupation.PATCH.Errors.Status500.ErrorCodes
       | ModelInfo.Enums.GET.Response.ErrorCodes
       | SkillsAPI.POST.Errors.Status400.ErrorCodes
       | SkillsAPI.POST.Errors.Status404.ErrorCodes
@@ -117,6 +123,12 @@ namespace ErrorTypes {
       | OccupationAPI.POST.Errors.Status400.ErrorCodes
       | OccupationAPI.POST.Errors.Status404.ErrorCodes
       | OccupationAPI.POST.Errors.Status500.ErrorCodes
+      | OccupationAPI.Occupation.PUT.Errors.Status400.ErrorCodes
+      | OccupationAPI.Occupation.PUT.Errors.Status404.ErrorCodes
+      | OccupationAPI.Occupation.PUT.Errors.Status500.ErrorCodes
+      | OccupationAPI.Occupation.PATCH.Errors.Status400.ErrorCodes
+      | OccupationAPI.Occupation.PATCH.Errors.Status404.ErrorCodes
+      | OccupationAPI.Occupation.PATCH.Errors.Status500.ErrorCodes
       | SkillsAPI.POST.Errors.Status400.ErrorCodes
       | SkillsAPI.POST.Errors.Status404.ErrorCodes
       | SkillsAPI.POST.Errors.Status500.ErrorCodes;
@@ -164,6 +176,8 @@ namespace ErrorTypes {
       | OccupationAPI.Occupation.Parent.GET.Errors.Status500.ErrorCodes
       | OccupationAPI.Occupation.Children.GET.Errors.Status500.ErrorCodes
       | OccupationAPI.Occupation.Skills.GET.Errors.Status500.ErrorCodes
+      | OccupationAPI.Occupation.PUT.Errors.Status404.ErrorCodes
+      | OccupationAPI.Occupation.PATCH.Errors.Status404.ErrorCodes
       | SkillsAPI.GET.Errors.Status400.ErrorCodes
       | SkillsAPI.GET.Errors.Status404.ErrorCodes
       | SkillsAPI.GET.Errors.Status500.ErrorCodes
@@ -183,7 +197,12 @@ namespace ErrorTypes {
     details: string;
   }
   export interface PATCH {
-    errorCode: ErrorConstants.Common.ErrorCodes | ErrorConstants.PATCH.ErrorCodes;
+    errorCode:
+      | ErrorConstants.Common.ErrorCodes
+      | ErrorConstants.PATCH.ErrorCodes
+      | OccupationAPI.Occupation.PATCH.Errors.Status400.ErrorCodes
+      | OccupationAPI.Occupation.PATCH.Errors.Status404.ErrorCodes
+      | OccupationAPI.Occupation.PATCH.Errors.Status500.ErrorCodes;
     message: string;
     details: string;
   }

--- a/api-specifications/src/esco/occupation/POST/schema.request.test.ts
+++ b/api-specifications/src/esco/occupation/POST/schema.request.test.ts
@@ -278,34 +278,26 @@ describe("Test objects against the OccupationAPISpecs.POSTOccupation.Schemas.Req
           constructSchemaError(
             "/occupationGroupCode",
             "pattern",
-            `must match pattern "${OccupationAPISpecs.Patterns.Str.LOCAL_GROUP_CODE}"`
-          ),
-        ],
-        [
-          CaseType.Failure,
-          "an invalid code",
-          "1234",
-          OccupationEnums.OccupationType.LocalOccupation,
-          constructSchemaError(
-            "/occupationGroupCode",
-            "pattern",
-            `must match pattern "${OccupationAPISpecs.Patterns.Str.LOCAL_GROUP_CODE}"`
-          ),
-        ],
-        [
-          CaseType.Failure,
-          "a valid code of different type",
-          getTestISCOGroupCode(),
-          OccupationEnums.OccupationType.LocalOccupation,
-          constructSchemaError(
-            "/occupationGroupCode",
-            "pattern",
-            `must match pattern "${OccupationAPISpecs.Patterns.Str.LOCAL_GROUP_CODE}"`
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.LOCAL_GROUP_CODE}|${OccupationAPISpecs.Patterns.Str.ISCO_GROUP_CODE}"`
           ),
         ],
         [
           CaseType.Success,
-          "a valid code",
+          "a valid ISCO numeric code",
+          "1234",
+          OccupationEnums.OccupationType.LocalOccupation,
+          undefined,
+        ],
+        [
+          CaseType.Success,
+          "a valid ISCO group code",
+          getTestISCOGroupCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          undefined,
+        ],
+        [
+          CaseType.Success,
+          "a valid local group code",
           getTestLocalGroupCode(),
           OccupationEnums.OccupationType.LocalOccupation,
           undefined,

--- a/api-specifications/src/esco/occupation/POST/schema.request.ts
+++ b/api-specifications/src/esco/occupation/POST/schema.request.ts
@@ -41,7 +41,7 @@ const SchemaPOSTRequest: SchemaObject = {
       occupationGroupCode: {
         type: "string",
         maxLength: OccupationConstants.CODE_PATTERN_MAX_LENGTH,
-        pattern: OccupationRegexes.Str.LOCAL_GROUP_CODE,
+        pattern: `${OccupationRegexes.Str.LOCAL_GROUP_CODE}|${OccupationRegexes.Str.ISCO_GROUP_CODE}`,
       },
     },
   },

--- a/api-specifications/src/esco/occupation/[id]/PATCH/constants.ts
+++ b/api-specifications/src/esco/occupation/[id]/PATCH/constants.ts
@@ -1,0 +1,22 @@
+import OccupationConstants from "../../_shared/constants";
+
+namespace PATCHOccupationConstants {
+  export const MAX_JSON_OVERHEAD = 10_000;
+
+  export const MAX_PATCH_PAYLOAD_LENGTH =
+    OccupationConstants.DESCRIPTION_MAX_LENGTH +
+    OccupationConstants.DEFINITION_MAX_LENGTH +
+    OccupationConstants.PREFERRED_LABEL_MAX_LENGTH +
+    OccupationConstants.ALT_LABELS_MAX_ITEMS * OccupationConstants.ALT_LABEL_MAX_LENGTH +
+    OccupationConstants.ORIGIN_URI_MAX_LENGTH +
+    OccupationConstants.PATH_URI_MAX_LENGTH +
+    OccupationConstants.TABIYA_PATH_URI_MAX_LENGTH +
+    OccupationConstants.SCOPE_NOTE_MAX_LENGTH +
+    OccupationConstants.REGULATED_PROFESSION_NOTE_MAX_LENGTH +
+    OccupationConstants.CODE_MAX_LENGTH +
+    OccupationConstants.OCCUPATION_GROUP_CODE_MAX_LENGTH +
+    OccupationConstants.UUID_HISTORY_MAX_ITEMS * OccupationConstants.UUID_HISTORY_MAX_LENGTH +
+    MAX_JSON_OVERHEAD;
+}
+
+export default PATCHOccupationConstants;

--- a/api-specifications/src/esco/occupation/[id]/PATCH/enums.ts
+++ b/api-specifications/src/esco/occupation/[id]/PATCH/enums.ts
@@ -1,0 +1,22 @@
+namespace PATCHOccupationErrors {
+  export namespace Status400 {
+    export enum ErrorCodes {
+      OCCUPATION_COULD_NOT_VALIDATE = "OCCUPATION_COULD_NOT_VALIDATE",
+      UNABLE_TO_ALTER_RELEASED_MODEL = "UNABLE_TO_ALTER_RELEASED_MODEL",
+      INVALID_MODEL_ID = "INVALID_MODEL_ID",
+    }
+  }
+  export namespace Status404 {
+    export enum ErrorCodes {
+      MODEL_NOT_FOUND = "MODEL_NOT_FOUND",
+      OCCUPATION_NOT_FOUND = "OCCUPATION_NOT_FOUND",
+    }
+  }
+  export namespace Status500 {
+    export enum ErrorCodes {
+      DB_FAILED_TO_UPDATE_OCCUPATION = "DB_FAILED_TO_UPDATE_OCCUPATION",
+    }
+  }
+}
+
+export default PATCHOccupationErrors;

--- a/api-specifications/src/esco/occupation/[id]/PATCH/index.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/PATCH/index.test.ts
@@ -1,0 +1,17 @@
+import PATCHOccupationOperation from "./index";
+
+describe("Test the PATCHOccupationOperation index", () => {
+  test("it should export the PATCHOccupationOperation namespace", () => {
+    expect(PATCHOccupationOperation).toBeDefined();
+  });
+
+  test("it should have the Schemas namespace defined", () => {
+    expect(PATCHOccupationOperation.Schemas).toBeDefined();
+    expect(PATCHOccupationOperation.Schemas.Response.Payload).toBeDefined();
+    expect(PATCHOccupationOperation.Schemas.Request.Payload).toBeDefined();
+  });
+
+  test("it should have the Errors namespace defined", () => {
+    expect(PATCHOccupationOperation.Errors).toBeDefined();
+  });
+});

--- a/api-specifications/src/esco/occupation/[id]/PATCH/index.ts
+++ b/api-specifications/src/esco/occupation/[id]/PATCH/index.ts
@@ -1,0 +1,30 @@
+import OccupationEnums from "../../_shared/enums";
+import OccupationTypes from "../../_shared/types";
+import PATCHOccupationErrors from "./enums";
+import PATCHOccupationConstants from "./constants";
+import SchemaPATCHRequest from "./schema.request";
+import SchemaPATCHResponse from "./schema.response";
+
+namespace PATCHOccupationOperation {
+  export namespace Schemas {
+    export namespace Request {
+      export const Payload = SchemaPATCHRequest;
+    }
+    export namespace Response {
+      export const Payload = SchemaPATCHResponse;
+    }
+  }
+  export namespace Types {
+    export namespace Request {
+      export type Payload = OccupationTypes.Detail.PATCH.Request.Payload;
+    }
+    export namespace Response {
+      export type Payload = OccupationTypes.Detail.PATCH.Response.Payload;
+    }
+  }
+  export import Errors = PATCHOccupationErrors;
+  export import Constants = PATCHOccupationConstants;
+  export import Enums = OccupationEnums;
+}
+
+export default PATCHOccupationOperation;

--- a/api-specifications/src/esco/occupation/[id]/PATCH/schema.request.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/PATCH/schema.request.test.ts
@@ -155,6 +155,13 @@ describe("Test objects against the OccupationAPISpecs.Occupation.PATCH.Schemas.R
           OccupationEnums.OccupationType.LocalOccupation,
           undefined,
         ],
+        [
+          CaseType.Success,
+          "a valid ISCO group code",
+          getTestISCOGroupCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          undefined,
+        ],
       ] as const)(
         "%s Validate 'occupationGroupCode' when it is %s with %s occupationType",
         (caseType, _description, givenValue, occupationType, failureMessage) => {

--- a/api-specifications/src/esco/occupation/[id]/PATCH/schema.request.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/PATCH/schema.request.test.ts
@@ -1,0 +1,400 @@
+import {
+  testSchemaWithAdditionalProperties,
+  testSchemaWithValidObject,
+  testValidSchema,
+} from "_test_utilities/stdSchemaTests";
+import { getTestString } from "../../../../_test_utilities/specialCharacters";
+import {
+  getTestLocalGroupCode,
+  getTestESCOOccupationCode,
+  getTestISCOGroupCode,
+  getTestLocalOccupationCode,
+  getTestESCOLocalOccupationCode,
+} from "../../../_test_utilities/testUtils";
+import { CaseType, assertCaseForProperty, constructSchemaError } from "_test_utilities/assertCaseForProperty";
+import OccupationAPISpecs from "../../index";
+import { getMockId } from "_test_utilities/mockMongoId";
+import OccupationEnums from "../../_shared/enums";
+import { RegExp_Str_ID } from "../../../../regex";
+
+describe("OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload schema", () => {
+  testValidSchema(
+    "OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload",
+    OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload
+  );
+});
+
+describe("Test objects against the OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload schema", () => {
+  testSchemaWithValidObject(
+    "empty payload (all fields optional)",
+    OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+    {}
+  );
+
+  testSchemaWithValidObject("single field payload", OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload, {
+    preferredLabel: "updated label",
+  });
+
+  testSchemaWithAdditionalProperties(
+    "payload with additional properties",
+    OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+    {
+      extraProperty: "extra test property (not defined in schema) for testing additionalProperties",
+    }
+  );
+
+  describe("OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload fields", () => {
+    describe("Test validation of 'code' when occupationType is provided", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "null",
+          null,
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError("/code", "type", "must be string"),
+        ],
+        [
+          CaseType.Failure,
+          "empty string",
+          "",
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError(
+            "/code",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ESCO_OCCUPATION_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Failure,
+          "a valid code of different type",
+          getTestLocalOccupationCode(),
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError(
+            "/code",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ESCO_OCCUPATION_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Success,
+          "a valid code",
+          getTestESCOOccupationCode(),
+          OccupationEnums.OccupationType.ESCOOccupation,
+          undefined,
+        ],
+        [
+          CaseType.Failure,
+          "a valid code of different type",
+          getTestESCOOccupationCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          constructSchemaError(
+            "/code",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Success,
+          "a valid local occupation code",
+          getTestLocalOccupationCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          undefined,
+        ],
+        [
+          CaseType.Success,
+          "a valid ESCO local occupation code",
+          getTestESCOLocalOccupationCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          undefined,
+        ],
+      ] as const)(
+        "%s Validate 'code' when it is %s with %s occupationType",
+        (caseType, _description, givenValue, occupationType, failureMessage) => {
+          assertCaseForProperty(
+            "code",
+            { code: givenValue, occupationType },
+            OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+            caseType,
+            failureMessage
+          );
+        }
+      );
+    });
+
+    describe("Test validation of 'occupationGroupCode' when occupationType is provided", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "null",
+          null,
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError("/occupationGroupCode", "type", "must be string"),
+        ],
+        [
+          CaseType.Failure,
+          "a valid code of different type",
+          getTestLocalGroupCode(),
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError(
+            "/occupationGroupCode",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ISCO_GROUP_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Success,
+          "a valid code",
+          getTestISCOGroupCode(),
+          OccupationEnums.OccupationType.ESCOOccupation,
+          undefined,
+        ],
+        [
+          CaseType.Success,
+          "a valid code",
+          getTestLocalGroupCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          undefined,
+        ],
+      ] as const)(
+        "%s Validate 'occupationGroupCode' when it is %s with %s occupationType",
+        (caseType, _description, givenValue, occupationType, failureMessage) => {
+          assertCaseForProperty(
+            "occupationGroupCode",
+            { occupationGroupCode: givenValue, occupationType },
+            OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+            caseType,
+            failureMessage
+          );
+        }
+      );
+    });
+
+    describe("Test validation of description", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/description", "type", "must be string")],
+        [CaseType.Failure, "a number", 123, constructSchemaError("/description", "type", "must be string")],
+        [CaseType.Success, "a valid string", getTestString(100), undefined],
+      ])("(%s) Validate 'description' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "description",
+          { description: value },
+          OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of preferredLabel", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/preferredLabel", "type", "must be string")],
+        [
+          CaseType.Failure,
+          "empty string",
+          "",
+          constructSchemaError("/preferredLabel", "pattern", `must match pattern "\\S"`),
+        ],
+        [CaseType.Success, "a valid string", "label", undefined],
+      ])("(%s) Validate 'preferredLabel' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "preferredLabel",
+          { preferredLabel: value },
+          OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of 'altLabels'", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/altLabels", "type", "must be array")],
+        [CaseType.Failure, "empty string", "", constructSchemaError("/altLabels", "type", "must be array")],
+        [
+          CaseType.Failure,
+          "array of objects",
+          [{}, {}],
+          [
+            constructSchemaError("/altLabels/0", "type", "must be string"),
+            constructSchemaError("/altLabels/1", "type", "must be string"),
+          ],
+        ],
+        [CaseType.Success, "an array of valid strings", [getTestString(100), getTestString(50)], undefined],
+      ])("(%s) Validate 'altLabels' when %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "altLabels",
+          { altLabels: value },
+          OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of 'definition'", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/definition", "type", "must be string")],
+        [CaseType.Failure, "a number", 123, constructSchemaError("/definition", "type", "must be string")],
+        [CaseType.Success, "a valid string", getTestString(100), undefined],
+      ])("(%s) Validate 'definition' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "definition",
+          { definition: value },
+          OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of 'originUri'", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/originUri", "type", "must be string")],
+        [
+          CaseType.Failure,
+          "empty string",
+          "",
+          constructSchemaError("/originUri", "pattern", `must match pattern "\\S"`),
+        ],
+        [
+          CaseType.Failure,
+          "invalid format",
+          "not-a-uri",
+          constructSchemaError("/originUri", "format", 'must match format "uri"'),
+        ],
+        [CaseType.Success, "a valid URI", "https://example.com", undefined],
+      ])("(%s) Validate 'originUri' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "originUri",
+          { originUri: value },
+          OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of 'modelId'", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/modelId", "type", "must be string")],
+        [
+          CaseType.Failure,
+          "invalid ObjectId",
+          "not-a-valid-id",
+          constructSchemaError("/modelId", "pattern", `must match pattern "${RegExp_Str_ID}"`),
+        ],
+        [CaseType.Success, "a valid ObjectId", getMockId(1), undefined],
+      ])("(%s) Validate 'modelId' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "modelId",
+          { modelId: value },
+          OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of 'UUIDHistory'", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/UUIDHistory", "type", "must be array")],
+        [CaseType.Failure, "empty string", "", constructSchemaError("/UUIDHistory", "type", "must be array")],
+        [CaseType.Success, "empty array", [], undefined],
+      ])("(%s) Validate 'UUIDHistory' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "UUIDHistory",
+          { UUIDHistory: value },
+          OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of 'regulatedProfessionNote'", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/regulatedProfessionNote", "type", "must be string")],
+        [CaseType.Success, "a valid string", "note", undefined],
+      ])("(%s) Validate 'regulatedProfessionNote' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "regulatedProfessionNote",
+          { regulatedProfessionNote: value },
+          OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of 'scopeNote'", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/scopeNote", "type", "must be string")],
+        [CaseType.Success, "a valid string", "note", undefined],
+      ])("(%s) Validate 'scopeNote' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "scopeNote",
+          { scopeNote: value },
+          OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of 'isLocalized'", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Success, "true", true, undefined],
+        [CaseType.Success, "false", false, undefined],
+        [CaseType.Failure, "string", "true", constructSchemaError("/isLocalized", "type", "must be boolean")],
+        [CaseType.Failure, "number", 1, constructSchemaError("/isLocalized", "type", "must be boolean")],
+      ])("(%s) Validate 'isLocalized' when %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "isLocalized",
+          { isLocalized: value },
+          OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of occupationType", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/occupationType", "type", "must be string")],
+        [
+          CaseType.Failure,
+          "empty string",
+          "",
+          constructSchemaError("/occupationType", "enum", "must be equal to one of the allowed values"),
+        ],
+        [
+          CaseType.Failure,
+          "invalid",
+          "invalidType",
+          constructSchemaError("/occupationType", "enum", "must be equal to one of the allowed values"),
+        ],
+        [CaseType.Success, "ESCOOccupation", OccupationEnums.OccupationType.ESCOOccupation, undefined],
+        [CaseType.Success, "LocalOccupation", OccupationEnums.OccupationType.LocalOccupation, undefined],
+      ])("%s Validate 'occupationType' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "occupationType",
+          { occupationType: value },
+          OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+  });
+});

--- a/api-specifications/src/esco/occupation/[id]/PATCH/schema.request.ts
+++ b/api-specifications/src/esco/occupation/[id]/PATCH/schema.request.ts
@@ -12,6 +12,7 @@ const SchemaPATCHRequest: SchemaObject = {
     ..._baseProperties,
   },
   if: {
+    required: ["occupationType"],
     properties: {
       occupationType: { const: OccupationEnums.OccupationType.ESCOOccupation },
     },
@@ -31,16 +32,24 @@ const SchemaPATCHRequest: SchemaObject = {
     },
   },
   else: {
-    properties: {
-      code: {
-        type: "string",
-        maxLength: OccupationConstants.CODE_PATTERN_MAX_LENGTH,
-        pattern: OccupationRegexes.Str.ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE,
+    if: {
+      required: ["occupationType"],
+      properties: {
+        occupationType: { const: OccupationEnums.OccupationType.LocalOccupation },
       },
-      occupationGroupCode: {
-        type: "string",
-        maxLength: OccupationConstants.CODE_PATTERN_MAX_LENGTH,
-        pattern: OccupationRegexes.Str.LOCAL_GROUP_CODE,
+    },
+    then: {
+      properties: {
+        code: {
+          type: "string",
+          maxLength: OccupationConstants.CODE_PATTERN_MAX_LENGTH,
+          pattern: OccupationRegexes.Str.ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE,
+        },
+        occupationGroupCode: {
+          type: "string",
+          maxLength: OccupationConstants.CODE_PATTERN_MAX_LENGTH,
+          pattern: `${OccupationRegexes.Str.LOCAL_GROUP_CODE}|${OccupationRegexes.Str.ISCO_GROUP_CODE}`,
+        },
       },
     },
   },

--- a/api-specifications/src/esco/occupation/[id]/PATCH/schema.request.ts
+++ b/api-specifications/src/esco/occupation/[id]/PATCH/schema.request.ts
@@ -1,12 +1,11 @@
-// src/.../schema.POST.request.ts
 import { SchemaObject } from "ajv";
-import { _baseProperties } from "../_shared/schemas.base";
-import OccupationEnums from "../_shared/enums";
-import OccupationRegexes from "../_shared/regex";
-import OccupationConstants from "../_shared/constants";
+import { _baseProperties } from "../../_shared/schemas.base";
+import OccupationEnums from "../../_shared/enums";
+import OccupationRegexes from "../../_shared/regex";
+import OccupationConstants from "../../_shared/constants";
 
-const SchemaPOSTRequest: SchemaObject = {
-  $id: "/components/schemas/OccupationRequestSchemaPOST",
+const SchemaPATCHRequest: SchemaObject = {
+  $id: "/components/schemas/OccupationRequestSchemaPATCH",
   type: "object",
   additionalProperties: false,
   properties: {
@@ -45,22 +44,6 @@ const SchemaPOSTRequest: SchemaObject = {
       },
     },
   },
-
-  required: [
-    "code",
-    "occupationGroupCode",
-    "preferredLabel",
-    "originUri",
-    "UUIDHistory",
-    "altLabels",
-    "definition",
-    "description",
-    "regulatedProfessionNote",
-    "scopeNote",
-    "modelId",
-    "occupationType",
-    "isLocalized",
-  ],
 };
 
-export default SchemaPOSTRequest;
+export default SchemaPATCHRequest;

--- a/api-specifications/src/esco/occupation/[id]/PATCH/schema.response.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/PATCH/schema.response.test.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from "crypto";
+import {
+  testSchemaWithAdditionalProperties,
+  testSchemaWithValidObject,
+  testValidSchema,
+} from "_test_utilities/stdSchemaTests";
+
+import OccupationAPISpecs from "../../index";
+import { getMockId } from "_test_utilities/mockMongoId";
+import OccupationEnums from "../../_shared/enums";
+import OccupationConstants from "../../_shared/constants";
+import { getTestString } from "../../../../_test_utilities/specialCharacters";
+import {
+  getTestESCOOccupationCode,
+  getTestESCOLocalOccupationCode,
+  getTestISCOGroupCode,
+} from "../../../_test_utilities/testUtils";
+
+describe("Test OccupationAPISpecs schema validity", () => {
+  testValidSchema(
+    "OccupationAPISpecs.Occupation.PATCH.Schemas.Response.Payload",
+    OccupationAPISpecs.Occupation.PATCH.Schemas.Response.Payload
+  );
+});
+
+describe("Test objects against the OccupationAPISpecs.Occupation.PATCH.Schemas.Response.Payload schema", () => {
+  const givenParent = {
+    id: getMockId(1),
+    UUID: randomUUID(),
+    code: getTestISCOGroupCode(),
+    occupationGroupCode: getTestISCOGroupCode(),
+    preferredLabel: getTestString(OccupationAPISpecs.Constants.PREFERRED_LABEL_MAX_LENGTH),
+    objectType: OccupationEnums.Relations.Parent.ObjectTypes.ISCOGroup,
+  };
+
+  const givenChild = {
+    id: getMockId(2),
+    UUID: randomUUID(),
+    code: getTestESCOLocalOccupationCode(),
+    preferredLabel: getTestString(OccupationAPISpecs.Constants.PREFERRED_LABEL_MAX_LENGTH),
+    objectType: OccupationEnums.Relations.Children.ObjectTypes.LocalOccupation,
+  };
+
+  const givenSkill = {
+    id: getMockId(1),
+    UUID: randomUUID(),
+    preferredLabel: getTestString(OccupationConstants.PREFERRED_LABEL_MAX_LENGTH),
+    isLocalized: true,
+    objectType: OccupationEnums.Relations.RequiredSkills.ObjectTypes.Skill,
+    relationType: OccupationEnums.OccupationToSkillRelationType.ESSENTIAL,
+    signallingValue: null,
+    signallingValueLabel: null,
+  };
+
+  const givenValidOccupationPATCHResponse = {
+    id: getMockId(4),
+    UUID: randomUUID(),
+    UUIDHistory: [randomUUID(), randomUUID()],
+    originUUID: randomUUID(),
+    code: getTestESCOOccupationCode(),
+    path: "https://path/to/tabiya",
+    tabiyaPath: "https://path/to/tabiya",
+    originUri: "https://foo/bar",
+    occupationGroupCode: getTestISCOGroupCode(),
+    description: getTestString(50),
+    preferredLabel: getTestString(20),
+    altLabels: [getTestString(OccupationConstants.ALT_LABEL_MAX_LENGTH)],
+    definition: getTestString(100),
+    regulatedProfessionNote: getTestString(75),
+    scopeNote: getTestString(60),
+    occupationType: OccupationEnums.OccupationType.ESCOOccupation,
+    modelId: getMockId(5),
+    isLocalized: true,
+    parent: givenParent,
+    children: [givenChild],
+    requiresSkills: [givenSkill],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  testSchemaWithValidObject(
+    "OccupationAPISpecs.Occupation.PATCH.Schemas.Response.Payload",
+    OccupationAPISpecs.Occupation.PATCH.Schemas.Response.Payload,
+    givenValidOccupationPATCHResponse
+  );
+
+  testSchemaWithAdditionalProperties(
+    "OccupationAPISpecs.Occupation.PATCH.Schemas.Response.Payload",
+    OccupationAPISpecs.Occupation.PATCH.Schemas.Response.Payload,
+    {
+      ...givenValidOccupationPATCHResponse,
+      extraProperty: "extra test property (not defined in schema) for testing additionalProperties",
+    }
+  );
+});

--- a/api-specifications/src/esco/occupation/[id]/PATCH/schema.response.ts
+++ b/api-specifications/src/esco/occupation/[id]/PATCH/schema.response.ts
@@ -1,0 +1,9 @@
+import { SchemaObject } from "ajv";
+import { _baseResponseSchema } from "../../_shared/schemas.base";
+
+const SchemaPATCHResponse: SchemaObject = {
+  ..._baseResponseSchema,
+  $id: "/components/schemas/OccupationResponseSchemaPATCH",
+};
+
+export default SchemaPATCHResponse;

--- a/api-specifications/src/esco/occupation/[id]/PUT/constants.ts
+++ b/api-specifications/src/esco/occupation/[id]/PUT/constants.ts
@@ -1,0 +1,22 @@
+import OccupationConstants from "../../_shared/constants";
+
+namespace PUTOccupationConstants {
+  export const MAX_JSON_OVERHEAD = 10_000;
+
+  export const MAX_PUT_PAYLOAD_LENGTH =
+    OccupationConstants.DESCRIPTION_MAX_LENGTH +
+    OccupationConstants.DEFINITION_MAX_LENGTH +
+    OccupationConstants.PREFERRED_LABEL_MAX_LENGTH +
+    OccupationConstants.ALT_LABELS_MAX_ITEMS * OccupationConstants.ALT_LABEL_MAX_LENGTH +
+    OccupationConstants.ORIGIN_URI_MAX_LENGTH +
+    OccupationConstants.PATH_URI_MAX_LENGTH +
+    OccupationConstants.TABIYA_PATH_URI_MAX_LENGTH +
+    OccupationConstants.SCOPE_NOTE_MAX_LENGTH +
+    OccupationConstants.REGULATED_PROFESSION_NOTE_MAX_LENGTH +
+    OccupationConstants.CODE_MAX_LENGTH +
+    OccupationConstants.OCCUPATION_GROUP_CODE_MAX_LENGTH +
+    OccupationConstants.UUID_HISTORY_MAX_ITEMS * OccupationConstants.UUID_HISTORY_MAX_LENGTH +
+    MAX_JSON_OVERHEAD;
+}
+
+export default PUTOccupationConstants;

--- a/api-specifications/src/esco/occupation/[id]/PUT/enums.ts
+++ b/api-specifications/src/esco/occupation/[id]/PUT/enums.ts
@@ -1,0 +1,22 @@
+namespace PUTOccupationErrors {
+  export namespace Status400 {
+    export enum ErrorCodes {
+      OCCUPATION_COULD_NOT_VALIDATE = "OCCUPATION_COULD_NOT_VALIDATE",
+      UNABLE_TO_ALTER_RELEASED_MODEL = "UNABLE_TO_ALTER_RELEASED_MODEL",
+      INVALID_MODEL_ID = "INVALID_MODEL_ID",
+    }
+  }
+  export namespace Status404 {
+    export enum ErrorCodes {
+      MODEL_NOT_FOUND = "MODEL_NOT_FOUND",
+      OCCUPATION_NOT_FOUND = "OCCUPATION_NOT_FOUND",
+    }
+  }
+  export namespace Status500 {
+    export enum ErrorCodes {
+      DB_FAILED_TO_UPDATE_OCCUPATION = "DB_FAILED_TO_UPDATE_OCCUPATION",
+    }
+  }
+}
+
+export default PUTOccupationErrors;

--- a/api-specifications/src/esco/occupation/[id]/PUT/index.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/PUT/index.test.ts
@@ -1,0 +1,17 @@
+import PUTOccupationOperation from "./index";
+
+describe("Test the PUTOccupationOperation index", () => {
+  test("it should export the PUTOccupationOperation namespace", () => {
+    expect(PUTOccupationOperation).toBeDefined();
+  });
+
+  test("it should have the Schemas namespace defined", () => {
+    expect(PUTOccupationOperation.Schemas).toBeDefined();
+    expect(PUTOccupationOperation.Schemas.Response.Payload).toBeDefined();
+    expect(PUTOccupationOperation.Schemas.Request.Payload).toBeDefined();
+  });
+
+  test("it should have the Errors namespace defined", () => {
+    expect(PUTOccupationOperation.Errors).toBeDefined();
+  });
+});

--- a/api-specifications/src/esco/occupation/[id]/PUT/index.ts
+++ b/api-specifications/src/esco/occupation/[id]/PUT/index.ts
@@ -1,0 +1,30 @@
+import OccupationEnums from "../../_shared/enums";
+import OccupationTypes from "../../_shared/types";
+import PUTOccupationErrors from "./enums";
+import PUTOccupationConstants from "./constants";
+import SchemaPUTRequest from "./schema.request";
+import SchemaPUTResponse from "./schema.response";
+
+namespace PUTOccupationOperation {
+  export namespace Schemas {
+    export namespace Request {
+      export const Payload = SchemaPUTRequest;
+    }
+    export namespace Response {
+      export const Payload = SchemaPUTResponse;
+    }
+  }
+  export namespace Types {
+    export namespace Request {
+      export type Payload = OccupationTypes.Detail.PUT.Request.Payload;
+    }
+    export namespace Response {
+      export type Payload = OccupationTypes.Detail.PUT.Response.Payload;
+    }
+  }
+  export import Errors = PUTOccupationErrors;
+  export import Constants = PUTOccupationConstants;
+  export import Enums = OccupationEnums;
+}
+
+export default PUTOccupationOperation;

--- a/api-specifications/src/esco/occupation/[id]/PUT/schema.request.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/PUT/schema.request.test.ts
@@ -1,0 +1,484 @@
+import {
+  testStringField,
+  testNonEmptyStringField,
+  testSchemaWithAdditionalProperties,
+  testSchemaWithValidObject,
+  testValidSchema,
+  testObjectIdField,
+  testUUIDArray,
+  testNonEmptyURIStringField,
+} from "_test_utilities/stdSchemaTests";
+
+import { randomUUID } from "crypto";
+import { getTestString } from "../../../../_test_utilities/specialCharacters";
+import {
+  getTestLocalGroupCode,
+  getTestESCOOccupationCode,
+  getTestISCOGroupCode,
+  getTestLocalOccupationCode,
+  getTestESCOLocalOccupationCode,
+} from "../../../_test_utilities/testUtils";
+import { CaseType, assertCaseForProperty, constructSchemaError } from "_test_utilities/assertCaseForProperty";
+import OccupationAPISpecs from "../../index";
+import OccupationConstants from "../../_shared/constants";
+import { getMockId } from "_test_utilities/mockMongoId";
+import LocaleAPISpecs from "locale";
+import ModelInfoAPISpecs from "modelInfo";
+import OccupationEnums from "../../_shared/enums";
+
+describe("OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload schema", () => {
+  testValidSchema(
+    "OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload",
+    OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload
+  );
+});
+
+describe("Test objects against the OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload schema", () => {
+  const createValidRequestPayload = (occupationType: OccupationEnums.OccupationType) => ({
+    code:
+      occupationType === OccupationEnums.OccupationType.ESCOOccupation
+        ? getTestESCOOccupationCode()
+        : getTestLocalOccupationCode(),
+    originUri: "https://example.com",
+    occupationGroupCode:
+      occupationType === OccupationEnums.OccupationType.ESCOOccupation
+        ? getTestISCOGroupCode()
+        : getTestLocalGroupCode(),
+    description: getTestString(OccupationConstants.DESCRIPTION_MAX_LENGTH),
+    preferredLabel: getTestString(OccupationConstants.PREFERRED_LABEL_MAX_LENGTH),
+    altLabels: [getTestString(OccupationConstants.ALT_LABEL_MAX_LENGTH)],
+    definition: getTestString(OccupationConstants.DEFINITION_MAX_LENGTH),
+    regulatedProfessionNote: getTestString(OccupationConstants.REGULATED_PROFESSION_NOTE_MAX_LENGTH),
+    scopeNote: getTestString(OccupationConstants.SCOPE_NOTE_MAX_LENGTH),
+    modelId: getMockId(1),
+    UUIDHistory: [randomUUID(), randomUUID()],
+    occupationType,
+    isLocalized: true,
+  });
+
+  const validPayload = createValidRequestPayload(OccupationEnums.OccupationType.ESCOOccupation);
+
+  testSchemaWithValidObject("valid payload", OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload, validPayload, [
+    LocaleAPISpecs.Schemas.Payload,
+    ModelInfoAPISpecs.Schemas.POST.Request.Payload,
+  ]);
+
+  const payloadWithEmptyUUIDHistory = { ...validPayload, UUIDHistory: [] };
+  testSchemaWithValidObject(
+    "payload with empty UUIDHistory",
+    OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload,
+    payloadWithEmptyUUIDHistory
+  );
+
+  testSchemaWithAdditionalProperties(
+    "payload with additional properties",
+    OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload,
+    {
+      ...validPayload,
+      extraProperty: "extra test property (not defined in schema) for testing additionalProperties",
+    }
+  );
+
+  describe("OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload fields", () => {
+    describe("Test validation of 'originUri'", () => {
+      testNonEmptyURIStringField<OccupationAPISpecs.Types.POSTOccupation.Request.Payload>(
+        "originUri",
+        OccupationAPISpecs.Constants.ORIGIN_URI_MAX_LENGTH,
+        OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload
+      );
+    });
+
+    describe("Test validation of 'code'", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "undefined",
+          undefined,
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError("", "required", "must have required property 'code'"),
+        ],
+        [
+          CaseType.Failure,
+          "null",
+          null,
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError("/code", "type", "must be string"),
+        ],
+        [
+          CaseType.Failure,
+          "empty string",
+          "",
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError(
+            "/code",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ESCO_OCCUPATION_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Failure,
+          "an invalid code",
+          "1234",
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError(
+            "/code",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ESCO_OCCUPATION_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Failure,
+          "a valid code of different type",
+          getTestLocalOccupationCode(),
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError(
+            "/code",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ESCO_OCCUPATION_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Success,
+          "a valid code",
+          getTestESCOOccupationCode(),
+          OccupationEnums.OccupationType.ESCOOccupation,
+          undefined,
+        ],
+        [
+          CaseType.Failure,
+          "empty string",
+          "",
+          OccupationEnums.OccupationType.LocalOccupation,
+          constructSchemaError(
+            "/code",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Failure,
+          "an invalid code",
+          "1234",
+          OccupationEnums.OccupationType.LocalOccupation,
+          constructSchemaError(
+            "/code",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Failure,
+          "a valid code of different type",
+          getTestESCOOccupationCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          constructSchemaError(
+            "/code",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Success,
+          "a valid local occupation code",
+          getTestLocalOccupationCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          undefined,
+        ],
+        [
+          CaseType.Success,
+          "a valid ESCO local occupation code",
+          getTestESCOLocalOccupationCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          undefined,
+        ],
+      ] as const)(
+        "%s Validate 'code' when it is %s with %s occupationType",
+        (caseType, _description, givenValue, occupationType, failureMessage) => {
+          const givenObject = {
+            ...createValidRequestPayload(occupationType),
+            code: givenValue,
+          };
+
+          assertCaseForProperty(
+            "code",
+            givenObject,
+            OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload,
+            caseType,
+            failureMessage
+          );
+        }
+      );
+    });
+
+    describe("Test validation of 'occupationGroupCode'", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "undefined",
+          undefined,
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError("", "required", "must have required property 'occupationGroupCode'"),
+        ],
+        [
+          CaseType.Failure,
+          "null",
+          null,
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError("/occupationGroupCode", "type", "must be string"),
+        ],
+        [
+          CaseType.Failure,
+          "empty string",
+          "",
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError(
+            "/occupationGroupCode",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ISCO_GROUP_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Failure,
+          "an invalid code",
+          "abcd",
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError(
+            "/occupationGroupCode",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ISCO_GROUP_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Failure,
+          "a valid code of different type",
+          getTestLocalGroupCode(),
+          OccupationEnums.OccupationType.ESCOOccupation,
+          constructSchemaError(
+            "/occupationGroupCode",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.ISCO_GROUP_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Success,
+          "a valid code",
+          getTestISCOGroupCode(),
+          OccupationEnums.OccupationType.ESCOOccupation,
+          undefined,
+        ],
+        [
+          CaseType.Failure,
+          "empty string",
+          "",
+          OccupationEnums.OccupationType.LocalOccupation,
+          constructSchemaError(
+            "/occupationGroupCode",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.LOCAL_GROUP_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Failure,
+          "an invalid code",
+          "1234",
+          OccupationEnums.OccupationType.LocalOccupation,
+          constructSchemaError(
+            "/occupationGroupCode",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.LOCAL_GROUP_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Failure,
+          "a valid code of different type",
+          getTestISCOGroupCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          constructSchemaError(
+            "/occupationGroupCode",
+            "pattern",
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.LOCAL_GROUP_CODE}"`
+          ),
+        ],
+        [
+          CaseType.Success,
+          "a valid code",
+          getTestLocalGroupCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          undefined,
+        ],
+      ] as const)(
+        "%s Validate 'occupationGroupCode' when it is %s with %s occupationType",
+        (caseType, _description, givenValue, occupationType, failureMessage) => {
+          const givenObject = {
+            ...createValidRequestPayload(occupationType),
+            occupationGroupCode: givenValue,
+          };
+
+          assertCaseForProperty(
+            "occupationGroupCode",
+            givenObject,
+            OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload,
+            caseType,
+            failureMessage
+          );
+        }
+      );
+    });
+
+    describe("Test validation of description", () => {
+      testStringField<OccupationAPISpecs.Types.POSTOccupation.Request.Payload>(
+        "description",
+        OccupationAPISpecs.Constants.DESCRIPTION_MAX_LENGTH,
+        OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload
+      );
+    });
+
+    describe("Test validation of preferredLabel", () => {
+      testNonEmptyStringField<OccupationAPISpecs.Types.POSTOccupation.Request.Payload>(
+        "preferredLabel",
+        OccupationAPISpecs.Constants.PREFERRED_LABEL_MAX_LENGTH,
+        OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload
+      );
+    });
+
+    describe("Test validation of 'altLabels'", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "undefined",
+          undefined,
+          constructSchemaError("", "required", "must have required property 'altLabels'"),
+        ],
+        [CaseType.Failure, "null", null, constructSchemaError("/altLabels", "type", "must be array")],
+        [CaseType.Failure, "empty string", "", constructSchemaError("/altLabels", "type", "must be array")],
+        [
+          CaseType.Failure,
+          "array of objects",
+          [{}, {}],
+          [
+            constructSchemaError("/altLabels/0", "type", "must be string"),
+            constructSchemaError("/altLabels/1", "type", "must be string"),
+          ],
+        ],
+        [
+          CaseType.Failure,
+          "an array of same strings",
+          ["foo", "foo"],
+          constructSchemaError(
+            "/altLabels",
+            "uniqueItems",
+            "must NOT have duplicate items (items ## 1 and 0 are identical)"
+          ),
+        ],
+        [
+          CaseType.Success,
+          "an array of valid strings",
+          [
+            getTestString(OccupationAPISpecs.Constants.ALT_LABEL_MAX_LENGTH),
+            getTestString(OccupationAPISpecs.Constants.ALT_LABEL_MAX_LENGTH - 1),
+          ],
+          undefined,
+        ],
+      ])("(%s) Validate 'altLabels' when %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "altLabels",
+          { altLabels: value },
+          OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of 'definition'", () => {
+      testStringField<OccupationAPISpecs.Types.POSTOccupation.Request.Payload>(
+        "definition",
+        OccupationAPISpecs.Constants.DEFINITION_MAX_LENGTH,
+        OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload
+      );
+    });
+
+    describe("Test validation of 'regulatedProfessionNote'", () => {
+      testStringField<OccupationAPISpecs.Types.POSTOccupation.Request.Payload>(
+        "regulatedProfessionNote",
+        OccupationAPISpecs.Constants.REGULATED_PROFESSION_NOTE_MAX_LENGTH,
+        OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload
+      );
+    });
+
+    describe("Test validation of 'scopeNote'", () => {
+      testStringField<OccupationAPISpecs.Types.POSTOccupation.Request.Payload>(
+        "scopeNote",
+        OccupationAPISpecs.Constants.SCOPE_NOTE_MAX_LENGTH,
+        OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload
+      );
+    });
+
+    describe("Test validation of 'modelId'", () => {
+      testObjectIdField("modelId", OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload);
+    });
+
+    describe("Test validation of 'UUIDHistory'", () => {
+      testUUIDArray<OccupationAPISpecs.Types.POSTOccupation.Request.Payload>(
+        "UUIDHistory",
+        OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload,
+        [],
+        true,
+        true
+      );
+    });
+
+    describe("Test validation of occupationType", () => {
+      const givenSchema = OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload;
+
+      test.each([
+        [
+          CaseType.Failure,
+          "undefined",
+          undefined,
+          constructSchemaError("", "required", "must have required property 'occupationType'"),
+        ],
+        [CaseType.Failure, "null", null, constructSchemaError("/occupationType", "type", "must be string")],
+        [
+          CaseType.Failure,
+          "empty string",
+          "",
+          constructSchemaError("/occupationType", "enum", "must be equal to one of the allowed values"),
+        ],
+        [
+          CaseType.Failure,
+          "invalid",
+          "invalidType",
+          constructSchemaError("/occupationType", "enum", "must be equal to one of the allowed values"),
+        ],
+        [CaseType.Success, "ESCOOccupation", OccupationEnums.OccupationType.ESCOOccupation, undefined],
+        [CaseType.Success, "LocalOccupation", OccupationEnums.OccupationType.LocalOccupation, undefined],
+      ])("%s Validate 'occupationType' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty("occupationType", { occupationType: value }, givenSchema, caseType, failure);
+      });
+    });
+
+    describe("Test validation of isLocalized", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "undefined",
+          undefined,
+          constructSchemaError("", "required", "must have required property 'isLocalized'"),
+        ],
+        [CaseType.Success, "true", true, undefined],
+        [CaseType.Success, "false", false, undefined],
+        [CaseType.Failure, "string", "true", constructSchemaError("/isLocalized", "type", "must be boolean")],
+        [CaseType.Failure, "number", 1, constructSchemaError("/isLocalized", "type", "must be boolean")],
+      ])("(%s) Validate 'isLocalized' when %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "isLocalized",
+          { isLocalized: value },
+          OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+  });
+});

--- a/api-specifications/src/esco/occupation/[id]/PUT/schema.request.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/PUT/schema.request.test.ts
@@ -274,34 +274,26 @@ describe("Test objects against the OccupationAPISpecs.Occupation.PUT.Schemas.Req
           constructSchemaError(
             "/occupationGroupCode",
             "pattern",
-            `must match pattern "${OccupationAPISpecs.Patterns.Str.LOCAL_GROUP_CODE}"`
-          ),
-        ],
-        [
-          CaseType.Failure,
-          "an invalid code",
-          "1234",
-          OccupationEnums.OccupationType.LocalOccupation,
-          constructSchemaError(
-            "/occupationGroupCode",
-            "pattern",
-            `must match pattern "${OccupationAPISpecs.Patterns.Str.LOCAL_GROUP_CODE}"`
-          ),
-        ],
-        [
-          CaseType.Failure,
-          "a valid code of different type",
-          getTestISCOGroupCode(),
-          OccupationEnums.OccupationType.LocalOccupation,
-          constructSchemaError(
-            "/occupationGroupCode",
-            "pattern",
-            `must match pattern "${OccupationAPISpecs.Patterns.Str.LOCAL_GROUP_CODE}"`
+            `must match pattern "${OccupationAPISpecs.Patterns.Str.LOCAL_GROUP_CODE}|${OccupationAPISpecs.Patterns.Str.ISCO_GROUP_CODE}"`
           ),
         ],
         [
           CaseType.Success,
-          "a valid code",
+          "a valid ISCO numeric code",
+          "1234",
+          OccupationEnums.OccupationType.LocalOccupation,
+          undefined,
+        ],
+        [
+          CaseType.Success,
+          "a valid ISCO group code",
+          getTestISCOGroupCode(),
+          OccupationEnums.OccupationType.LocalOccupation,
+          undefined,
+        ],
+        [
+          CaseType.Success,
+          "a valid local group code",
           getTestLocalGroupCode(),
           OccupationEnums.OccupationType.LocalOccupation,
           undefined,

--- a/api-specifications/src/esco/occupation/[id]/PUT/schema.request.ts
+++ b/api-specifications/src/esco/occupation/[id]/PUT/schema.request.ts
@@ -40,7 +40,7 @@ const SchemaPUTRequest: SchemaObject = {
       occupationGroupCode: {
         type: "string",
         maxLength: OccupationConstants.CODE_PATTERN_MAX_LENGTH,
-        pattern: OccupationRegexes.Str.LOCAL_GROUP_CODE,
+        pattern: `${OccupationRegexes.Str.LOCAL_GROUP_CODE}|${OccupationRegexes.Str.ISCO_GROUP_CODE}`,
       },
     },
   },

--- a/api-specifications/src/esco/occupation/[id]/PUT/schema.request.ts
+++ b/api-specifications/src/esco/occupation/[id]/PUT/schema.request.ts
@@ -1,12 +1,11 @@
-// src/.../schema.POST.request.ts
 import { SchemaObject } from "ajv";
-import { _baseProperties } from "../_shared/schemas.base";
-import OccupationEnums from "../_shared/enums";
-import OccupationRegexes from "../_shared/regex";
-import OccupationConstants from "../_shared/constants";
+import { _baseProperties } from "../../_shared/schemas.base";
+import OccupationEnums from "../../_shared/enums";
+import OccupationRegexes from "../../_shared/regex";
+import OccupationConstants from "../../_shared/constants";
 
-const SchemaPOSTRequest: SchemaObject = {
-  $id: "/components/schemas/OccupationRequestSchemaPOST",
+const SchemaPUTRequest: SchemaObject = {
+  $id: "/components/schemas/OccupationRequestSchemaPUT",
   type: "object",
   additionalProperties: false,
   properties: {
@@ -63,4 +62,4 @@ const SchemaPOSTRequest: SchemaObject = {
   ],
 };
 
-export default SchemaPOSTRequest;
+export default SchemaPUTRequest;

--- a/api-specifications/src/esco/occupation/[id]/PUT/schema.response.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/PUT/schema.response.test.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from "crypto";
+import {
+  testSchemaWithAdditionalProperties,
+  testSchemaWithValidObject,
+  testValidSchema,
+} from "_test_utilities/stdSchemaTests";
+
+import OccupationAPISpecs from "../../index";
+import { getMockId } from "_test_utilities/mockMongoId";
+import OccupationEnums from "../../_shared/enums";
+import OccupationConstants from "../../_shared/constants";
+import { getTestString } from "../../../../_test_utilities/specialCharacters";
+import {
+  getTestESCOOccupationCode,
+  getTestESCOLocalOccupationCode,
+  getTestISCOGroupCode,
+} from "../../../_test_utilities/testUtils";
+
+describe("Test OccupationAPISpecs schema validity", () => {
+  testValidSchema(
+    "OccupationAPISpecs.Occupation.PUT.Schemas.Response.Payload",
+    OccupationAPISpecs.Occupation.PUT.Schemas.Response.Payload
+  );
+});
+
+describe("Test objects against the OccupationAPISpecs.Occupation.PUT.Schemas.Response.Payload schema", () => {
+  const givenParent = {
+    id: getMockId(1),
+    UUID: randomUUID(),
+    code: getTestISCOGroupCode(),
+    occupationGroupCode: getTestISCOGroupCode(),
+    preferredLabel: getTestString(OccupationAPISpecs.Constants.PREFERRED_LABEL_MAX_LENGTH),
+    objectType: OccupationEnums.Relations.Parent.ObjectTypes.ISCOGroup,
+  };
+
+  const givenChild = {
+    id: getMockId(2),
+    UUID: randomUUID(),
+    code: getTestESCOLocalOccupationCode(),
+    preferredLabel: getTestString(OccupationAPISpecs.Constants.PREFERRED_LABEL_MAX_LENGTH),
+    objectType: OccupationEnums.Relations.Children.ObjectTypes.LocalOccupation,
+  };
+
+  const givenSkill = {
+    id: getMockId(1),
+    UUID: randomUUID(),
+    preferredLabel: getTestString(OccupationConstants.PREFERRED_LABEL_MAX_LENGTH),
+    isLocalized: true,
+    objectType: OccupationEnums.Relations.RequiredSkills.ObjectTypes.Skill,
+    relationType: OccupationEnums.OccupationToSkillRelationType.ESSENTIAL,
+    signallingValue: null,
+    signallingValueLabel: null,
+  };
+
+  const givenValidOccupationPUTResponse = {
+    id: getMockId(4),
+    UUID: randomUUID(),
+    UUIDHistory: [randomUUID(), randomUUID()],
+    originUUID: randomUUID(),
+    code: getTestESCOOccupationCode(),
+    path: "https://path/to/tabiya",
+    tabiyaPath: "https://path/to/tabiya",
+    originUri: "https://foo/bar",
+    occupationGroupCode: getTestISCOGroupCode(),
+    description: getTestString(50),
+    preferredLabel: getTestString(20),
+    altLabels: [getTestString(OccupationConstants.ALT_LABEL_MAX_LENGTH)],
+    definition: getTestString(100),
+    regulatedProfessionNote: getTestString(75),
+    scopeNote: getTestString(60),
+    occupationType: OccupationEnums.OccupationType.ESCOOccupation,
+    modelId: getMockId(5),
+    isLocalized: true,
+    parent: givenParent,
+    children: [givenChild],
+    requiresSkills: [givenSkill],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  testSchemaWithValidObject(
+    "OccupationAPISpecs.Occupation.PUT.Schemas.Response.Payload",
+    OccupationAPISpecs.Occupation.PUT.Schemas.Response.Payload,
+    givenValidOccupationPUTResponse
+  );
+
+  testSchemaWithAdditionalProperties(
+    "OccupationAPISpecs.Occupation.PUT.Schemas.Response.Payload",
+    OccupationAPISpecs.Occupation.PUT.Schemas.Response.Payload,
+    {
+      ...givenValidOccupationPUTResponse,
+      extraProperty: "extra test property (not defined in schema) for testing additionalProperties",
+    }
+  );
+});

--- a/api-specifications/src/esco/occupation/[id]/PUT/schema.response.ts
+++ b/api-specifications/src/esco/occupation/[id]/PUT/schema.response.ts
@@ -1,0 +1,9 @@
+import { SchemaObject } from "ajv";
+import { _baseResponseSchema } from "../../_shared/schemas.base";
+
+const SchemaPUTResponse: SchemaObject = {
+  ..._baseResponseSchema,
+  $id: "/components/schemas/OccupationResponseSchemaPUT",
+};
+
+export default SchemaPUTResponse;

--- a/api-specifications/src/esco/occupation/[id]/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/esco/occupation/[id]/__snapshots__/index.test.ts.snap
@@ -883,16 +883,28 @@ exports[`Test the Occupation Instance module The export module matches the snaps
           "$id": "/components/schemas/OccupationRequestSchemaPATCH",
           "additionalProperties": false,
           "else": {
-            "properties": {
-              "code": {
-                "maxLength": 100,
-                "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
-                "type": "string",
+            "if": {
+              "properties": {
+                "occupationType": {
+                  "const": "localoccupation",
+                },
               },
-              "occupationGroupCode": {
-                "maxLength": 100,
-                "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
-                "type": "string",
+              "required": [
+                "occupationType",
+              ],
+            },
+            "then": {
+              "properties": {
+                "code": {
+                  "maxLength": 100,
+                  "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                  "type": "string",
+                },
+                "occupationGroupCode": {
+                  "maxLength": 100,
+                  "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                  "type": "string",
+                },
               },
             },
           },
@@ -902,6 +914,9 @@ exports[`Test the Occupation Instance module The export module matches the snaps
                 "const": "escooccupation",
               },
             },
+            "required": [
+              "occupationType",
+            ],
           },
           "properties": {
             "UUIDHistory": {
@@ -1652,7 +1667,7 @@ exports[`Test the Occupation Instance module The export module matches the snaps
               },
               "occupationGroupCode": {
                 "maxLength": 100,
-                "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
                 "type": "string",
               },
             },

--- a/api-specifications/src/esco/occupation/[id]/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/esco/occupation/[id]/__snapshots__/index.test.ts.snap
@@ -7,6 +7,7 @@ exports[`Test the Occupation Instance module The export module matches the snaps
       "ALT_LABELS_MAX_ITEMS": 100,
       "ALT_LABEL_MAX_LENGTH": 256,
       "CODE_MAX_LENGTH": 256,
+      "CODE_PATTERN_MAX_LENGTH": 100,
       "DEFAULT_LIMIT": 10,
       "DEFINITION_MAX_LENGTH": 4000,
       "DESCRIPTION_MAX_LENGTH": 6000,
@@ -734,6 +735,7 @@ exports[`Test the Occupation Instance module The export module matches the snaps
     "ALT_LABELS_MAX_ITEMS": 100,
     "ALT_LABEL_MAX_LENGTH": 256,
     "CODE_MAX_LENGTH": 256,
+    "CODE_PATTERN_MAX_LENGTH": 100,
     "DEFAULT_LIMIT": 10,
     "DEFINITION_MAX_LENGTH": 4000,
     "DESCRIPTION_MAX_LENGTH": 6000,
@@ -816,29 +818,10 @@ exports[`Test the Occupation Instance module The export module matches the snaps
       },
     },
   },
-  "History": {
+  "PATCH": {
     "Constants": {
-      "ALT_LABELS_MAX_ITEMS": 100,
-      "ALT_LABEL_MAX_LENGTH": 256,
-      "CODE_MAX_LENGTH": 256,
-      "DEFAULT_LIMIT": 10,
-      "DEFINITION_MAX_LENGTH": 4000,
-      "DESCRIPTION_MAX_LENGTH": 6000,
-      "MAX_CURSOR_LENGTH": 1024,
-      "MAX_LIMIT": 100,
-      "MAX_PAYLOAD_LENGTH": 1000,
-      "OCCUPATION_GROUP_CODE_MAX_LENGTH": 256,
-      "ORIGIN_URI_MAX_LENGTH": 4096,
-      "PATH_URI_MAX_LENGTH": 4096,
-      "PREFERRED_LABEL_MAX_LENGTH": 256,
-      "REGULATED_PROFESSION_NOTE_MAX_LENGTH": 4000,
-      "SCOPE_NOTE_MAX_LENGTH": 4000,
-      "SIGNALLING_VALUE_LABEL_MAX_LENGTH": 256,
-      "SIGNALLING_VALUE_MAX": 100,
-      "SIGNALLING_VALUE_MIN": 0,
-      "TABIYA_PATH_URI_MAX_LENGTH": 4096,
-      "UUID_HISTORY_MAX_ITEMS": 10000,
-      "UUID_HISTORY_MAX_LENGTH": 50,
+      "MAX_JSON_OVERHEAD": 10000,
+      "MAX_PATCH_PAYLOAD_LENGTH": 566656,
     },
     "Enums": {
       "OccupationToSkillRelationType": {
@@ -874,116 +857,1510 @@ exports[`Test the Occupation Instance module The export module matches the snaps
         },
       },
     },
-    "GET": {
-      "Errors": {
-        "Status400": {
-          "ErrorCodes": {
-            "INVALID_OCCUPATION_ID": "INVALID_OCCUPATION_ID",
-          },
-        },
-        "Status404": {
-          "ErrorCodes": {
-            "MODEL_NOT_FOUND": "MODEL_NOT_FOUND",
-            "OCCUPATION_NOT_FOUND": "OCCUPATION_NOT_FOUND",
-          },
-        },
-        "Status500": {
-          "ErrorCodes": {
-            "DB_FAILED_TO_RETRIEVE_OCCUPATION_HISTORY": "DB_FAILED_TO_RETRIEVE_OCCUPATION_HISTORY",
-          },
+    "Errors": {
+      "Status400": {
+        "ErrorCodes": {
+          "INVALID_MODEL_ID": "INVALID_MODEL_ID",
+          "OCCUPATION_COULD_NOT_VALIDATE": "OCCUPATION_COULD_NOT_VALIDATE",
+          "UNABLE_TO_ALTER_RELEASED_MODEL": "UNABLE_TO_ALTER_RELEASED_MODEL",
         },
       },
-      "Schemas": {
-        "Response": {
-          "Payload": {
-            "$id": "/components/schemas/OccupationResponseSchemaGETHistory",
-            "items": {
+      "Status404": {
+        "ErrorCodes": {
+          "MODEL_NOT_FOUND": "MODEL_NOT_FOUND",
+          "OCCUPATION_NOT_FOUND": "OCCUPATION_NOT_FOUND",
+        },
+      },
+      "Status500": {
+        "ErrorCodes": {
+          "DB_FAILED_TO_UPDATE_OCCUPATION": "DB_FAILED_TO_UPDATE_OCCUPATION",
+        },
+      },
+    },
+    "Schemas": {
+      "Request": {
+        "Payload": {
+          "$id": "/components/schemas/OccupationRequestSchemaPATCH",
+          "additionalProperties": false,
+          "else": {
+            "properties": {
+              "code": {
+                "maxLength": 100,
+                "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                "type": "string",
+              },
+              "occupationGroupCode": {
+                "maxLength": 100,
+                "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                "type": "string",
+              },
+            },
+          },
+          "if": {
+            "properties": {
+              "occupationType": {
+                "const": "escooccupation",
+              },
+            },
+          },
+          "properties": {
+            "UUIDHistory": {
+              "description": "The UUIDs history of the occupation.",
+              "items": {
+                "maxLength": 50,
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                "type": "string",
+              },
+              "maxItems": 10000,
+              "minItems": 0,
+              "type": "array",
+              "uniqueItems": true,
+            },
+            "altLabels": {
+              "description": "Alternative labels for the occupation.",
+              "items": {
+                "maxLength": 256,
+                "type": "string",
+              },
+              "maxItems": 100,
+              "minItems": 0,
+              "type": "array",
+              "uniqueItems": true,
+            },
+            "code": {
+              "description": "The code of the occupation.",
+              "maxLength": 256,
+              "type": "string",
+            },
+            "definition": {
+              "description": "The formal definition of the occupation.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+            "description": {
+              "description": "Additional descriptive information about the occupation.",
+              "maxLength": 6000,
+              "type": "string",
+            },
+            "isLocalized": {
+              "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
+              "type": "boolean",
+            },
+            "modelId": {
+              "description": "The identifier of the model containing this occupation.",
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string",
+            },
+            "occupationGroupCode": {
+              "description": "The code of the parent occupation group.",
+              "maxLength": 256,
+              "type": "string",
+            },
+            "occupationType": {
+              "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
+              "enum": [
+                "escooccupation",
+                "localoccupation",
+              ],
+              "type": "string",
+            },
+            "originUri": {
+              "description": "The origin URI of the occupation.",
+              "format": "uri",
+              "maxLength": 4096,
+              "pattern": "\\S",
+              "type": "string",
+            },
+            "preferredLabel": {
+              "description": "The preferred label of the occupation.",
+              "maxLength": 256,
+              "pattern": "\\S",
+              "type": "string",
+            },
+            "regulatedProfessionNote": {
+              "description": "Regulatory information for legally regulated professions.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+            "scopeNote": {
+              "description": "Scope clarification for the occupation's application.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+          },
+          "then": {
+            "properties": {
+              "code": {
+                "maxLength": 100,
+                "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                "type": "string",
+              },
+              "occupationGroupCode": {
+                "maxLength": 100,
+                "pattern": "^\\d{1,4}$",
+                "type": "string",
+              },
+            },
+          },
+          "type": "object",
+        },
+      },
+      "Response": {
+        "Payload": {
+          "$id": "/components/schemas/OccupationResponseSchemaPATCH",
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "occupationType": {
+                    "const": "escooccupation",
+                  },
+                },
+              },
+              "then": {
+                "properties": {
+                  "code": {
+                    "maxLength": 256,
+                    "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                    "type": "string",
+                  },
+                  "occupationGroupCode": {
+                    "maxLength": 256,
+                    "pattern": "^\\d{1,4}$",
+                    "type": "string",
+                  },
+                },
+              },
+            },
+            {
+              "if": {
+                "properties": {
+                  "occupationType": {
+                    "const": "localoccupation",
+                  },
+                },
+              },
+              "then": {
+                "properties": {
+                  "code": {
+                    "maxLength": 256,
+                    "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                    "type": "string",
+                  },
+                  "occupationGroupCode": {
+                    "maxLength": 256,
+                    "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                    "type": "string",
+                  },
+                },
+              },
+            },
+            {
+              "if": {
+                "properties": {
+                  "occupationType": {
+                    "const": "escooccupation",
+                  },
+                },
+              },
+              "then": {
+                "properties": {
+                  "requiresSkills": {
+                    "items": {
+                      "properties": {
+                        "relationType": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "relationType",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                },
+              },
+            },
+            {
+              "if": {
+                "properties": {
+                  "occupationType": {
+                    "const": "localoccupation",
+                  },
+                },
+              },
+              "then": {
+                "properties": {
+                  "requiresSkills": {
+                    "items": {
+                      "properties": {
+                        "signallingValue": {
+                          "type": "number",
+                        },
+                        "signallingValueLabel": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "signallingValue",
+                        "signallingValueLabel",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                },
+              },
+            },
+          ],
+          "properties": {
+            "UUID": {
+              "description": "The UUID of the occupation for cross-system identification.",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+              "type": "string",
+            },
+            "UUIDHistory": {
+              "description": "The UUIDs history of the occupation.",
+              "items": {
+                "maxLength": 50,
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                "type": "string",
+              },
+              "maxItems": 10000,
+              "minItems": 0,
+              "type": "array",
+              "uniqueItems": true,
+            },
+            "altLabels": {
+              "description": "Alternative labels for the occupation.",
+              "items": {
+                "maxLength": 256,
+                "type": "string",
+              },
+              "maxItems": 100,
+              "minItems": 0,
+              "type": "array",
+              "uniqueItems": true,
+            },
+            "children": {
+              "description": "The children of this occupation.",
+              "items": {
+                "additionalProperties": false,
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "escooccupation",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{1,4}$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "localoccupation",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                ],
+                "properties": {
+                  "UUID": {
+                    "description": "The UUID of the child occupation.",
+                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    "type": "string",
+                  },
+                  "code": {
+                    "description": "The code of the child occupation.",
+                    "maxLength": 256,
+                    "type": "string",
+                  },
+                  "id": {
+                    "description": "The id of the child occupation.",
+                    "pattern": "^[0-9a-f]{24}$",
+                    "type": "string",
+                  },
+                  "objectType": {
+                    "description": "The type of the occupation child (EscoOccupation or LocalOccupation).",
+                    "enum": [
+                      "escooccupation",
+                      "localoccupation",
+                    ],
+                    "type": "string",
+                  },
+                  "occupationGroupCode": {
+                    "description": "The code of the child occupation group.",
+                    "maxLength": 256,
+                    "type": "string",
+                  },
+                  "preferredLabel": {
+                    "description": "The preferred label of the child occupation.",
+                    "maxLength": 256,
+                    "pattern": "\\S",
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+              "minItems": 0,
+              "type": "array",
+            },
+            "code": {
+              "description": "The code of the occupation.",
+              "maxLength": 256,
+              "type": "string",
+            },
+            "createdAt": {
+              "description": "Timestamp of record creation.",
+              "format": "date-time",
+              "type": "string",
+            },
+            "definition": {
+              "description": "The formal definition of the occupation.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+            "description": {
+              "description": "Additional descriptive information about the occupation.",
+              "maxLength": 6000,
+              "type": "string",
+            },
+            "id": {
+              "description": "The unique identifier of the occupation.",
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string",
+            },
+            "isLocalized": {
+              "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
+              "type": "boolean",
+            },
+            "modelId": {
+              "description": "The identifier of the model containing this occupation.",
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string",
+            },
+            "occupationGroupCode": {
+              "description": "The code of the parent occupation group.",
+              "maxLength": 256,
+              "type": "string",
+            },
+            "occupationType": {
+              "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
+              "enum": [
+                "escooccupation",
+                "localoccupation",
+              ],
+              "type": "string",
+            },
+            "originUUID": {
+              "description": "The original UUID of the occupation, i.e., the first UUID in UUIDHistory",
+              "maxLength": 50,
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+              "type": "string",
+            },
+            "originUri": {
+              "description": "The origin URI of the occupation.",
+              "format": "uri",
+              "maxLength": 4096,
+              "pattern": "\\S",
+              "type": "string",
+            },
+            "parent": {
               "additionalProperties": false,
+              "allOf": [
+                {
+                  "if": {
+                    "properties": {
+                      "objectType": {
+                        "const": "iscogroup",
+                      },
+                    },
+                  },
+                  "then": {
+                    "properties": {
+                      "code": {
+                        "maxLength": 256,
+                        "pattern": "^\\d{1,4}$",
+                        "type": "string",
+                      },
+                      "occupationGroupCode": {
+                        "maxLength": 256,
+                        "pattern": "^\\d{1,4}$",
+                        "type": "string",
+                      },
+                    },
+                  },
+                },
+                {
+                  "if": {
+                    "properties": {
+                      "objectType": {
+                        "const": "localgroup",
+                      },
+                    },
+                  },
+                  "then": {
+                    "properties": {
+                      "code": {
+                        "maxLength": 256,
+                        "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                        "type": "string",
+                      },
+                      "occupationGroupCode": {
+                        "maxLength": 256,
+                        "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                        "type": "string",
+                      },
+                    },
+                  },
+                },
+                {
+                  "if": {
+                    "properties": {
+                      "objectType": {
+                        "const": "escooccupation",
+                      },
+                    },
+                  },
+                  "then": {
+                    "properties": {
+                      "code": {
+                        "maxLength": 256,
+                        "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                        "type": "string",
+                      },
+                      "occupationGroupCode": {
+                        "maxLength": 256,
+                        "pattern": "^\\d{1,4}$",
+                        "type": "string",
+                      },
+                    },
+                  },
+                },
+                {
+                  "if": {
+                    "properties": {
+                      "objectType": {
+                        "const": "localoccupation",
+                      },
+                    },
+                  },
+                  "then": {
+                    "properties": {
+                      "code": {
+                        "maxLength": 256,
+                        "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                        "type": "string",
+                      },
+                      "occupationGroupCode": {
+                        "maxLength": 256,
+                        "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                        "type": "string",
+                      },
+                    },
+                  },
+                },
+              ],
+              "description": "The parent occupation of this occupation.",
               "properties": {
                 "UUID": {
-                  "description": "The UUID of the occupation.",
+                  "description": "The UUID of the occupation. It can be used to identify the parent occupation.",
                   "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
                   "type": "string",
                 },
                 "code": {
-                  "description": "The code of the occupation.",
+                  "description": "The code of the parent occupation.",
                   "maxLength": 256,
                   "type": "string",
                 },
                 "id": {
-                  "description": "The id of the occupation.",
+                  "description": "The id of the parent occupation.",
                   "pattern": "^[0-9a-f]{24}$",
                   "type": "string",
                 },
-                "isLocalized": {
-                  "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
-                  "type": "boolean",
-                },
-                "model": {
-                  "$ref": "/components/schemas/ModelInfoReferenceSchema",
+                "objectType": {
+                  "description": "The type of the occupation parent (LocalOccupation, ESCOOccupation, ISCOGroup or LocalGroup).",
+                  "enum": [
+                    "iscogroup",
+                    "localgroup",
+                    "escooccupation",
+                    "localoccupation",
+                  ],
+                  "type": "string",
                 },
                 "occupationGroupCode": {
                   "description": "The code of the parent occupation group.",
                   "maxLength": 256,
                   "type": "string",
                 },
-                "occupationType": {
-                  "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
-                  "enum": [
-                    "escooccupation",
-                    "localoccupation",
-                  ],
-                  "type": "string",
-                },
                 "preferredLabel": {
-                  "description": "The preferred label of the occupation.",
+                  "description": "The preferred label of the parent occupation.",
                   "maxLength": 256,
                   "pattern": "\\S",
                   "type": "string",
                 },
               },
-              "required": [
-                "id",
-                "UUID",
-                "preferredLabel",
-                "occupationGroupCode",
-                "code",
-                "occupationType",
-                "isLocalized",
-                "model",
+              "type": [
+                "object",
+                "null",
               ],
-              "type": "object",
             },
-            "type": "array",
+            "path": {
+              "description": "Resource path using the occupation's ID.",
+              "format": "uri",
+              "maxLength": 4096,
+              "pattern": "^https://.*",
+              "type": "string",
+            },
+            "preferredLabel": {
+              "description": "The preferred label of the occupation.",
+              "maxLength": 256,
+              "pattern": "\\S",
+              "type": "string",
+            },
+            "regulatedProfessionNote": {
+              "description": "Regulatory information for legally regulated professions.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+            "requiresSkills": {
+              "description": "Skills required for this occupation with relationship metadata.",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "UUID": {
+                    "description": "The UUID of the required skill.",
+                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    "type": "string",
+                  },
+                  "id": {
+                    "description": "The ID of the required skill.",
+                    "pattern": "^[0-9a-f]{24}$",
+                    "type": "string",
+                  },
+                  "isLocalized": {
+                    "description": "Indicates if the required skill is localized.",
+                    "type": "boolean",
+                  },
+                  "objectType": {
+                    "description": "The object type of the required skill.",
+                    "enum": [
+                      "skill",
+                    ],
+                    "type": "string",
+                  },
+                  "preferredLabel": {
+                    "description": "The preferred label of the required skill.",
+                    "maxLength": 256,
+                    "pattern": "\\S",
+                    "type": "string",
+                  },
+                  "relationType": {
+                    "description": "Used for ESCOOccupations only.",
+                    "enum": [
+                      "",
+                      "essential",
+                      "optional",
+                      null,
+                    ],
+                    "type": [
+                      "string",
+                      "null",
+                    ],
+                  },
+                  "signallingValue": {
+                    "description": "Used for LocalOccupations only.",
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": [
+                      "number",
+                      "null",
+                    ],
+                  },
+                  "signallingValueLabel": {
+                    "description": "Used for LocalOccupations only.",
+                    "maxLength": 256,
+                    "pattern": "\\S",
+                    "type": [
+                      "string",
+                      "null",
+                    ],
+                  },
+                },
+                "required": [
+                  "id",
+                  "UUID",
+                  "preferredLabel",
+                  "isLocalized",
+                  "objectType",
+                ],
+                "type": "object",
+              },
+              "minItems": 0,
+              "type": "array",
+            },
+            "scopeNote": {
+              "description": "Scope clarification for the occupation's application.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+            "tabiyaPath": {
+              "description": "Resource path using the occupation's UUID.",
+              "format": "uri",
+              "maxLength": 4096,
+              "pattern": "^https://.*",
+              "type": "string",
+            },
+            "updatedAt": {
+              "description": "Timestamp of last record modification.",
+              "format": "date-time",
+              "type": "string",
+            },
+          },
+          "required": [
+            "id",
+            "UUID",
+            "originUUID",
+            "UUIDHistory",
+            "path",
+            "tabiyaPath",
+            "code",
+            "occupationGroupCode",
+            "originUri",
+            "preferredLabel",
+            "altLabels",
+            "definition",
+            "description",
+            "regulatedProfessionNote",
+            "scopeNote",
+            "occupationType",
+            "modelId",
+            "isLocalized",
+            "parent",
+            "requiresSkills",
+            "children",
+            "createdAt",
+            "updatedAt",
+          ],
+          "type": "object",
+        },
+      },
+    },
+  },
+  "PUT": {
+    "Constants": {
+      "MAX_JSON_OVERHEAD": 10000,
+      "MAX_PUT_PAYLOAD_LENGTH": 566656,
+    },
+    "Enums": {
+      "OccupationToSkillRelationType": {
+        "ESSENTIAL": "essential",
+        "NONE": "",
+        "OPTIONAL": "optional",
+      },
+      "OccupationType": {
+        "ESCOOccupation": "escooccupation",
+        "LocalOccupation": "localoccupation",
+      },
+      "Relations": {
+        "Children": {
+          "ObjectTypes": {
+            "ESCOOccupation": "escooccupation",
+            "ISCOGroup": "iscogroup",
+            "LocalGroup": "localgroup",
+            "LocalOccupation": "localoccupation",
+          },
+        },
+        "Parent": {
+          "ObjectTypes": {
+            "ESCOOccupation": "escooccupation",
+            "ISCOGroup": "iscogroup",
+            "LocalGroup": "localgroup",
+            "LocalOccupation": "localoccupation",
+          },
+        },
+        "RequiredSkills": {
+          "ObjectTypes": {
+            "Skill": "skill",
           },
         },
       },
     },
-    "Patterns": {
-      "RegExp": {
-        "ESCO_LOCAL_OCCUPATION_CODE": /\\^\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\*\\(\\?:_\\\\d\\+\\)\\+\\$/,
-        "ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE": /\\^\\(\\?:\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\*\\(\\?:_\\\\d\\+\\)\\+\\|\\[a-zA-Z\\\\d\\]\\+\\(\\?:_\\\\d\\+\\)\\+\\)\\$/,
-        "ESCO_OCCUPATION_CODE": /\\^\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\+\\$/,
-        "ISCO_GROUP_CODE": /\\^\\\\d\\{1,4\\}\\$/,
-        "LOCAL_GROUP_CODE": /\\^\\(\\?:\\\\d\\{1,4\\}\\)\\?\\[a-zA-Z\\]\\+\\[a-zA-Z\\\\d\\]\\*\\$/,
-        "LOCAL_OCCUPATION_CODE": /\\(\\^\\[a-zA-Z\\\\d\\]\\+\\)\\(\\?:_\\\\d\\+\\)\\+\\$/,
+    "Errors": {
+      "Status400": {
+        "ErrorCodes": {
+          "INVALID_MODEL_ID": "INVALID_MODEL_ID",
+          "OCCUPATION_COULD_NOT_VALIDATE": "OCCUPATION_COULD_NOT_VALIDATE",
+          "UNABLE_TO_ALTER_RELEASED_MODEL": "UNABLE_TO_ALTER_RELEASED_MODEL",
+        },
       },
-      "Str": {
-        "ESCO_LOCAL_OCCUPATION_CODE": "^\\d{4}(?:\\.\\d+)*(?:_\\d+)+$",
-        "ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
-        "ESCO_OCCUPATION_CODE": "^\\d{4}(?:\\.\\d+)+$",
-        "ISCO_GROUP_CODE": "^\\d{1,4}$",
-        "LOCAL_GROUP_CODE": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
-        "LOCAL_OCCUPATION_CODE": "(^[a-zA-Z\\d]+)(?:_\\d+)+$",
+      "Status404": {
+        "ErrorCodes": {
+          "MODEL_NOT_FOUND": "MODEL_NOT_FOUND",
+          "OCCUPATION_NOT_FOUND": "OCCUPATION_NOT_FOUND",
+        },
+      },
+      "Status500": {
+        "ErrorCodes": {
+          "DB_FAILED_TO_UPDATE_OCCUPATION": "DB_FAILED_TO_UPDATE_OCCUPATION",
+        },
       },
     },
-    "Types": {},
+    "Schemas": {
+      "Request": {
+        "Payload": {
+          "$id": "/components/schemas/OccupationRequestSchemaPUT",
+          "additionalProperties": false,
+          "else": {
+            "properties": {
+              "code": {
+                "maxLength": 100,
+                "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                "type": "string",
+              },
+              "occupationGroupCode": {
+                "maxLength": 100,
+                "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                "type": "string",
+              },
+            },
+          },
+          "if": {
+            "properties": {
+              "occupationType": {
+                "const": "escooccupation",
+              },
+            },
+          },
+          "properties": {
+            "UUIDHistory": {
+              "description": "The UUIDs history of the occupation.",
+              "items": {
+                "maxLength": 50,
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                "type": "string",
+              },
+              "maxItems": 10000,
+              "minItems": 0,
+              "type": "array",
+              "uniqueItems": true,
+            },
+            "altLabels": {
+              "description": "Alternative labels for the occupation.",
+              "items": {
+                "maxLength": 256,
+                "type": "string",
+              },
+              "maxItems": 100,
+              "minItems": 0,
+              "type": "array",
+              "uniqueItems": true,
+            },
+            "code": {
+              "description": "The code of the occupation.",
+              "maxLength": 256,
+              "type": "string",
+            },
+            "definition": {
+              "description": "The formal definition of the occupation.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+            "description": {
+              "description": "Additional descriptive information about the occupation.",
+              "maxLength": 6000,
+              "type": "string",
+            },
+            "isLocalized": {
+              "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
+              "type": "boolean",
+            },
+            "modelId": {
+              "description": "The identifier of the model containing this occupation.",
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string",
+            },
+            "occupationGroupCode": {
+              "description": "The code of the parent occupation group.",
+              "maxLength": 256,
+              "type": "string",
+            },
+            "occupationType": {
+              "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
+              "enum": [
+                "escooccupation",
+                "localoccupation",
+              ],
+              "type": "string",
+            },
+            "originUri": {
+              "description": "The origin URI of the occupation.",
+              "format": "uri",
+              "maxLength": 4096,
+              "pattern": "\\S",
+              "type": "string",
+            },
+            "preferredLabel": {
+              "description": "The preferred label of the occupation.",
+              "maxLength": 256,
+              "pattern": "\\S",
+              "type": "string",
+            },
+            "regulatedProfessionNote": {
+              "description": "Regulatory information for legally regulated professions.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+            "scopeNote": {
+              "description": "Scope clarification for the occupation's application.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+          },
+          "required": [
+            "code",
+            "occupationGroupCode",
+            "preferredLabel",
+            "originUri",
+            "UUIDHistory",
+            "altLabels",
+            "definition",
+            "description",
+            "regulatedProfessionNote",
+            "scopeNote",
+            "modelId",
+            "occupationType",
+            "isLocalized",
+          ],
+          "then": {
+            "properties": {
+              "code": {
+                "maxLength": 100,
+                "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                "type": "string",
+              },
+              "occupationGroupCode": {
+                "maxLength": 100,
+                "pattern": "^\\d{1,4}$",
+                "type": "string",
+              },
+            },
+          },
+          "type": "object",
+        },
+      },
+      "Response": {
+        "Payload": {
+          "$id": "/components/schemas/OccupationResponseSchemaPUT",
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "occupationType": {
+                    "const": "escooccupation",
+                  },
+                },
+              },
+              "then": {
+                "properties": {
+                  "code": {
+                    "maxLength": 256,
+                    "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                    "type": "string",
+                  },
+                  "occupationGroupCode": {
+                    "maxLength": 256,
+                    "pattern": "^\\d{1,4}$",
+                    "type": "string",
+                  },
+                },
+              },
+            },
+            {
+              "if": {
+                "properties": {
+                  "occupationType": {
+                    "const": "localoccupation",
+                  },
+                },
+              },
+              "then": {
+                "properties": {
+                  "code": {
+                    "maxLength": 256,
+                    "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                    "type": "string",
+                  },
+                  "occupationGroupCode": {
+                    "maxLength": 256,
+                    "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                    "type": "string",
+                  },
+                },
+              },
+            },
+            {
+              "if": {
+                "properties": {
+                  "occupationType": {
+                    "const": "escooccupation",
+                  },
+                },
+              },
+              "then": {
+                "properties": {
+                  "requiresSkills": {
+                    "items": {
+                      "properties": {
+                        "relationType": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "relationType",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                },
+              },
+            },
+            {
+              "if": {
+                "properties": {
+                  "occupationType": {
+                    "const": "localoccupation",
+                  },
+                },
+              },
+              "then": {
+                "properties": {
+                  "requiresSkills": {
+                    "items": {
+                      "properties": {
+                        "signallingValue": {
+                          "type": "number",
+                        },
+                        "signallingValueLabel": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "signallingValue",
+                        "signallingValueLabel",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                },
+              },
+            },
+          ],
+          "properties": {
+            "UUID": {
+              "description": "The UUID of the occupation for cross-system identification.",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+              "type": "string",
+            },
+            "UUIDHistory": {
+              "description": "The UUIDs history of the occupation.",
+              "items": {
+                "maxLength": 50,
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                "type": "string",
+              },
+              "maxItems": 10000,
+              "minItems": 0,
+              "type": "array",
+              "uniqueItems": true,
+            },
+            "altLabels": {
+              "description": "Alternative labels for the occupation.",
+              "items": {
+                "maxLength": 256,
+                "type": "string",
+              },
+              "maxItems": 100,
+              "minItems": 0,
+              "type": "array",
+              "uniqueItems": true,
+            },
+            "children": {
+              "description": "The children of this occupation.",
+              "items": {
+                "additionalProperties": false,
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "escooccupation",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{1,4}$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "localoccupation",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                ],
+                "properties": {
+                  "UUID": {
+                    "description": "The UUID of the child occupation.",
+                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    "type": "string",
+                  },
+                  "code": {
+                    "description": "The code of the child occupation.",
+                    "maxLength": 256,
+                    "type": "string",
+                  },
+                  "id": {
+                    "description": "The id of the child occupation.",
+                    "pattern": "^[0-9a-f]{24}$",
+                    "type": "string",
+                  },
+                  "objectType": {
+                    "description": "The type of the occupation child (EscoOccupation or LocalOccupation).",
+                    "enum": [
+                      "escooccupation",
+                      "localoccupation",
+                    ],
+                    "type": "string",
+                  },
+                  "occupationGroupCode": {
+                    "description": "The code of the child occupation group.",
+                    "maxLength": 256,
+                    "type": "string",
+                  },
+                  "preferredLabel": {
+                    "description": "The preferred label of the child occupation.",
+                    "maxLength": 256,
+                    "pattern": "\\S",
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+              "minItems": 0,
+              "type": "array",
+            },
+            "code": {
+              "description": "The code of the occupation.",
+              "maxLength": 256,
+              "type": "string",
+            },
+            "createdAt": {
+              "description": "Timestamp of record creation.",
+              "format": "date-time",
+              "type": "string",
+            },
+            "definition": {
+              "description": "The formal definition of the occupation.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+            "description": {
+              "description": "Additional descriptive information about the occupation.",
+              "maxLength": 6000,
+              "type": "string",
+            },
+            "id": {
+              "description": "The unique identifier of the occupation.",
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string",
+            },
+            "isLocalized": {
+              "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
+              "type": "boolean",
+            },
+            "modelId": {
+              "description": "The identifier of the model containing this occupation.",
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string",
+            },
+            "occupationGroupCode": {
+              "description": "The code of the parent occupation group.",
+              "maxLength": 256,
+              "type": "string",
+            },
+            "occupationType": {
+              "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
+              "enum": [
+                "escooccupation",
+                "localoccupation",
+              ],
+              "type": "string",
+            },
+            "originUUID": {
+              "description": "The original UUID of the occupation, i.e., the first UUID in UUIDHistory",
+              "maxLength": 50,
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+              "type": "string",
+            },
+            "originUri": {
+              "description": "The origin URI of the occupation.",
+              "format": "uri",
+              "maxLength": 4096,
+              "pattern": "\\S",
+              "type": "string",
+            },
+            "parent": {
+              "additionalProperties": false,
+              "allOf": [
+                {
+                  "if": {
+                    "properties": {
+                      "objectType": {
+                        "const": "iscogroup",
+                      },
+                    },
+                  },
+                  "then": {
+                    "properties": {
+                      "code": {
+                        "maxLength": 256,
+                        "pattern": "^\\d{1,4}$",
+                        "type": "string",
+                      },
+                      "occupationGroupCode": {
+                        "maxLength": 256,
+                        "pattern": "^\\d{1,4}$",
+                        "type": "string",
+                      },
+                    },
+                  },
+                },
+                {
+                  "if": {
+                    "properties": {
+                      "objectType": {
+                        "const": "localgroup",
+                      },
+                    },
+                  },
+                  "then": {
+                    "properties": {
+                      "code": {
+                        "maxLength": 256,
+                        "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                        "type": "string",
+                      },
+                      "occupationGroupCode": {
+                        "maxLength": 256,
+                        "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                        "type": "string",
+                      },
+                    },
+                  },
+                },
+                {
+                  "if": {
+                    "properties": {
+                      "objectType": {
+                        "const": "escooccupation",
+                      },
+                    },
+                  },
+                  "then": {
+                    "properties": {
+                      "code": {
+                        "maxLength": 256,
+                        "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                        "type": "string",
+                      },
+                      "occupationGroupCode": {
+                        "maxLength": 256,
+                        "pattern": "^\\d{1,4}$",
+                        "type": "string",
+                      },
+                    },
+                  },
+                },
+                {
+                  "if": {
+                    "properties": {
+                      "objectType": {
+                        "const": "localoccupation",
+                      },
+                    },
+                  },
+                  "then": {
+                    "properties": {
+                      "code": {
+                        "maxLength": 256,
+                        "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                        "type": "string",
+                      },
+                      "occupationGroupCode": {
+                        "maxLength": 256,
+                        "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                        "type": "string",
+                      },
+                    },
+                  },
+                },
+              ],
+              "description": "The parent occupation of this occupation.",
+              "properties": {
+                "UUID": {
+                  "description": "The UUID of the occupation. It can be used to identify the parent occupation.",
+                  "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                  "type": "string",
+                },
+                "code": {
+                  "description": "The code of the parent occupation.",
+                  "maxLength": 256,
+                  "type": "string",
+                },
+                "id": {
+                  "description": "The id of the parent occupation.",
+                  "pattern": "^[0-9a-f]{24}$",
+                  "type": "string",
+                },
+                "objectType": {
+                  "description": "The type of the occupation parent (LocalOccupation, ESCOOccupation, ISCOGroup or LocalGroup).",
+                  "enum": [
+                    "iscogroup",
+                    "localgroup",
+                    "escooccupation",
+                    "localoccupation",
+                  ],
+                  "type": "string",
+                },
+                "occupationGroupCode": {
+                  "description": "The code of the parent occupation group.",
+                  "maxLength": 256,
+                  "type": "string",
+                },
+                "preferredLabel": {
+                  "description": "The preferred label of the parent occupation.",
+                  "maxLength": 256,
+                  "pattern": "\\S",
+                  "type": "string",
+                },
+              },
+              "type": [
+                "object",
+                "null",
+              ],
+            },
+            "path": {
+              "description": "Resource path using the occupation's ID.",
+              "format": "uri",
+              "maxLength": 4096,
+              "pattern": "^https://.*",
+              "type": "string",
+            },
+            "preferredLabel": {
+              "description": "The preferred label of the occupation.",
+              "maxLength": 256,
+              "pattern": "\\S",
+              "type": "string",
+            },
+            "regulatedProfessionNote": {
+              "description": "Regulatory information for legally regulated professions.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+            "requiresSkills": {
+              "description": "Skills required for this occupation with relationship metadata.",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "UUID": {
+                    "description": "The UUID of the required skill.",
+                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    "type": "string",
+                  },
+                  "id": {
+                    "description": "The ID of the required skill.",
+                    "pattern": "^[0-9a-f]{24}$",
+                    "type": "string",
+                  },
+                  "isLocalized": {
+                    "description": "Indicates if the required skill is localized.",
+                    "type": "boolean",
+                  },
+                  "objectType": {
+                    "description": "The object type of the required skill.",
+                    "enum": [
+                      "skill",
+                    ],
+                    "type": "string",
+                  },
+                  "preferredLabel": {
+                    "description": "The preferred label of the required skill.",
+                    "maxLength": 256,
+                    "pattern": "\\S",
+                    "type": "string",
+                  },
+                  "relationType": {
+                    "description": "Used for ESCOOccupations only.",
+                    "enum": [
+                      "",
+                      "essential",
+                      "optional",
+                      null,
+                    ],
+                    "type": [
+                      "string",
+                      "null",
+                    ],
+                  },
+                  "signallingValue": {
+                    "description": "Used for LocalOccupations only.",
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": [
+                      "number",
+                      "null",
+                    ],
+                  },
+                  "signallingValueLabel": {
+                    "description": "Used for LocalOccupations only.",
+                    "maxLength": 256,
+                    "pattern": "\\S",
+                    "type": [
+                      "string",
+                      "null",
+                    ],
+                  },
+                },
+                "required": [
+                  "id",
+                  "UUID",
+                  "preferredLabel",
+                  "isLocalized",
+                  "objectType",
+                ],
+                "type": "object",
+              },
+              "minItems": 0,
+              "type": "array",
+            },
+            "scopeNote": {
+              "description": "Scope clarification for the occupation's application.",
+              "maxLength": 4000,
+              "type": "string",
+            },
+            "tabiyaPath": {
+              "description": "Resource path using the occupation's UUID.",
+              "format": "uri",
+              "maxLength": 4096,
+              "pattern": "^https://.*",
+              "type": "string",
+            },
+            "updatedAt": {
+              "description": "Timestamp of last record modification.",
+              "format": "date-time",
+              "type": "string",
+            },
+          },
+          "required": [
+            "id",
+            "UUID",
+            "originUUID",
+            "UUIDHistory",
+            "path",
+            "tabiyaPath",
+            "code",
+            "occupationGroupCode",
+            "originUri",
+            "preferredLabel",
+            "altLabels",
+            "definition",
+            "description",
+            "regulatedProfessionNote",
+            "scopeNote",
+            "occupationType",
+            "modelId",
+            "isLocalized",
+            "parent",
+            "requiresSkills",
+            "children",
+            "createdAt",
+            "updatedAt",
+          ],
+          "type": "object",
+        },
+      },
+    },
   },
   "Parent": {
     "Constants": {
       "ALT_LABELS_MAX_ITEMS": 100,
       "ALT_LABEL_MAX_LENGTH": 256,
       "CODE_MAX_LENGTH": 256,
+      "CODE_PATTERN_MAX_LENGTH": 100,
       "DEFAULT_LIMIT": 10,
       "DEFINITION_MAX_LENGTH": 4000,
       "DESCRIPTION_MAX_LENGTH": 6000,
@@ -2972,6 +4349,7 @@ exports[`Test the Occupation Instance module The export module matches the snaps
       "ALT_LABELS_MAX_ITEMS": 100,
       "ALT_LABEL_MAX_LENGTH": 256,
       "CODE_MAX_LENGTH": 256,
+      "CODE_PATTERN_MAX_LENGTH": 100,
       "DEFAULT_LIMIT": 10,
       "DEFINITION_MAX_LENGTH": 4000,
       "DESCRIPTION_MAX_LENGTH": 6000,

--- a/api-specifications/src/esco/occupation/[id]/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/esco/occupation/[id]/__snapshots__/index.test.ts.snap
@@ -818,6 +818,170 @@ exports[`Test the Occupation Instance module The export module matches the snaps
       },
     },
   },
+  "History": {
+    "Constants": {
+      "ALT_LABELS_MAX_ITEMS": 100,
+      "ALT_LABEL_MAX_LENGTH": 256,
+      "CODE_MAX_LENGTH": 256,
+      "CODE_PATTERN_MAX_LENGTH": 100,
+      "DEFAULT_LIMIT": 10,
+      "DEFINITION_MAX_LENGTH": 4000,
+      "DESCRIPTION_MAX_LENGTH": 6000,
+      "MAX_CURSOR_LENGTH": 1024,
+      "MAX_LIMIT": 100,
+      "MAX_PAYLOAD_LENGTH": 1000,
+      "OCCUPATION_GROUP_CODE_MAX_LENGTH": 256,
+      "ORIGIN_URI_MAX_LENGTH": 4096,
+      "PATH_URI_MAX_LENGTH": 4096,
+      "PREFERRED_LABEL_MAX_LENGTH": 256,
+      "REGULATED_PROFESSION_NOTE_MAX_LENGTH": 4000,
+      "SCOPE_NOTE_MAX_LENGTH": 4000,
+      "SIGNALLING_VALUE_LABEL_MAX_LENGTH": 256,
+      "SIGNALLING_VALUE_MAX": 100,
+      "SIGNALLING_VALUE_MIN": 0,
+      "TABIYA_PATH_URI_MAX_LENGTH": 4096,
+      "UUID_HISTORY_MAX_ITEMS": 10000,
+      "UUID_HISTORY_MAX_LENGTH": 50,
+    },
+    "Enums": {
+      "OccupationToSkillRelationType": {
+        "ESSENTIAL": "essential",
+        "NONE": "",
+        "OPTIONAL": "optional",
+      },
+      "OccupationType": {
+        "ESCOOccupation": "escooccupation",
+        "LocalOccupation": "localoccupation",
+      },
+      "Relations": {
+        "Children": {
+          "ObjectTypes": {
+            "ESCOOccupation": "escooccupation",
+            "ISCOGroup": "iscogroup",
+            "LocalGroup": "localgroup",
+            "LocalOccupation": "localoccupation",
+          },
+        },
+        "Parent": {
+          "ObjectTypes": {
+            "ESCOOccupation": "escooccupation",
+            "ISCOGroup": "iscogroup",
+            "LocalGroup": "localgroup",
+            "LocalOccupation": "localoccupation",
+          },
+        },
+        "RequiredSkills": {
+          "ObjectTypes": {
+            "Skill": "skill",
+          },
+        },
+      },
+    },
+    "GET": {
+      "Errors": {
+        "Status400": {
+          "ErrorCodes": {
+            "INVALID_OCCUPATION_ID": "INVALID_OCCUPATION_ID",
+          },
+        },
+        "Status404": {
+          "ErrorCodes": {
+            "MODEL_NOT_FOUND": "MODEL_NOT_FOUND",
+            "OCCUPATION_NOT_FOUND": "OCCUPATION_NOT_FOUND",
+          },
+        },
+        "Status500": {
+          "ErrorCodes": {
+            "DB_FAILED_TO_RETRIEVE_OCCUPATION_HISTORY": "DB_FAILED_TO_RETRIEVE_OCCUPATION_HISTORY",
+          },
+        },
+      },
+      "Schemas": {
+        "Response": {
+          "Payload": {
+            "$id": "/components/schemas/OccupationResponseSchemaGETHistory",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "UUID": {
+                  "description": "The UUID of the occupation.",
+                  "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                  "type": "string",
+                },
+                "code": {
+                  "description": "The code of the occupation.",
+                  "maxLength": 256,
+                  "type": "string",
+                },
+                "id": {
+                  "description": "The id of the occupation.",
+                  "pattern": "^[0-9a-f]{24}$",
+                  "type": "string",
+                },
+                "isLocalized": {
+                  "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
+                  "type": "boolean",
+                },
+                "model": {
+                  "$ref": "/components/schemas/ModelInfoReferenceSchema",
+                },
+                "occupationGroupCode": {
+                  "description": "The code of the parent occupation group.",
+                  "maxLength": 256,
+                  "type": "string",
+                },
+                "occupationType": {
+                  "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
+                  "enum": [
+                    "escooccupation",
+                    "localoccupation",
+                  ],
+                  "type": "string",
+                },
+                "preferredLabel": {
+                  "description": "The preferred label of the occupation.",
+                  "maxLength": 256,
+                  "pattern": "\\S",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "id",
+                "UUID",
+                "preferredLabel",
+                "occupationGroupCode",
+                "code",
+                "occupationType",
+                "isLocalized",
+                "model",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+      },
+    },
+    "Patterns": {
+      "RegExp": {
+        "ESCO_LOCAL_OCCUPATION_CODE": /\\^\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\*\\(\\?:_\\\\d\\+\\)\\+\\$/,
+        "ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE": /\\^\\(\\?:\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\*\\(\\?:_\\\\d\\+\\)\\+\\|\\[a-zA-Z\\\\d\\]\\+\\(\\?:_\\\\d\\+\\)\\+\\)\\$/,
+        "ESCO_OCCUPATION_CODE": /\\^\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\+\\$/,
+        "ISCO_GROUP_CODE": /\\^\\\\d\\{1,4\\}\\$/,
+        "LOCAL_GROUP_CODE": /\\^\\(\\?:\\\\d\\{1,4\\}\\)\\?\\[a-zA-Z\\]\\+\\[a-zA-Z\\\\d\\]\\*\\$/,
+        "LOCAL_OCCUPATION_CODE": /\\(\\^\\[a-zA-Z\\\\d\\]\\+\\)\\(\\?:_\\\\d\\+\\)\\+\\$/,
+      },
+      "Str": {
+        "ESCO_LOCAL_OCCUPATION_CODE": "^\\d{4}(?:\\.\\d+)*(?:_\\d+)+$",
+        "ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+        "ESCO_OCCUPATION_CODE": "^\\d{4}(?:\\.\\d+)+$",
+        "ISCO_GROUP_CODE": "^\\d{1,4}$",
+        "LOCAL_GROUP_CODE": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+        "LOCAL_OCCUPATION_CODE": "(^[a-zA-Z\\d]+)(?:_\\d+)+$",
+      },
+    },
+    "Types": {},
+  },
   "PATCH": {
     "Constants": {
       "MAX_JSON_OVERHEAD": 10000,

--- a/api-specifications/src/esco/occupation/[id]/children/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/esco/occupation/[id]/children/__snapshots__/index.test.ts.snap
@@ -6,6 +6,7 @@ exports[`Test the Occupation Children Instance Detail module The export module m
     "ALT_LABELS_MAX_ITEMS": 100,
     "ALT_LABEL_MAX_LENGTH": 256,
     "CODE_MAX_LENGTH": 256,
+    "CODE_PATTERN_MAX_LENGTH": 100,
     "DEFAULT_LIMIT": 10,
     "DEFINITION_MAX_LENGTH": 4000,
     "DESCRIPTION_MAX_LENGTH": 6000,

--- a/api-specifications/src/esco/occupation/[id]/history/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/esco/occupation/[id]/history/__snapshots__/index.test.ts.snap
@@ -6,6 +6,7 @@ exports[`Test the Occupation History Instance Detail module The export module ma
     "ALT_LABELS_MAX_ITEMS": 100,
     "ALT_LABEL_MAX_LENGTH": 256,
     "CODE_MAX_LENGTH": 256,
+    "CODE_PATTERN_MAX_LENGTH": 100,
     "DEFAULT_LIMIT": 10,
     "DEFINITION_MAX_LENGTH": 4000,
     "DESCRIPTION_MAX_LENGTH": 6000,

--- a/api-specifications/src/esco/occupation/[id]/index.ts
+++ b/api-specifications/src/esco/occupation/[id]/index.ts
@@ -4,6 +4,8 @@ import OccupationTypes from "../_shared/types";
 import OccupationRegexes from "../_shared/regex";
 
 import GETOccupationByIdOperation from "./GET";
+import PUTOccupationOperation from "./PUT";
+import PATCHOccupationOperation from "./PATCH";
 import OccupationParentAPISpecs from "./parent";
 import OccupationChildrenAPISpecs from "./children";
 import OccupationSkillsAPISpecs from "./skills";
@@ -17,9 +19,8 @@ namespace OccupationInstanceAPISpecs {
   export import Patterns = OccupationRegexes;
 
   export import GET = GETOccupationByIdOperation;
-  // Placeholders for future methods
-  // export import PUT = PUTOccupationOperation;
-  // export import DELETE = DELETEOccupationOperation;
+  export import PUT = PUTOccupationOperation;
+  export import PATCH = PATCHOccupationOperation;
 
   // Child API Paths
   export import Parent = OccupationParentAPISpecs;

--- a/api-specifications/src/esco/occupation/[id]/parent/POST/schema.request.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/parent/POST/schema.request.test.ts
@@ -1,0 +1,131 @@
+import {
+  testSchemaWithAdditionalProperties,
+  testSchemaWithValidObject,
+  testValidSchema,
+} from "_test_utilities/stdSchemaTests";
+import { CaseType, assertCaseForProperty, constructSchemaError } from "_test_utilities/assertCaseForProperty";
+import { getMockId } from "_test_utilities/mockMongoId";
+import { getStdObjectIdTestCases } from "_test_utilities/stdSchemaTestCases";
+import OccupationAPISpecs from "../../../index";
+import OccupationEnums from "../../../_shared/enums";
+
+describe("OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload schema", () => {
+  testValidSchema(
+    "OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload",
+    OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload
+  );
+});
+
+describe("Test objects against the OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload schema", () => {
+  const validPayload = {
+    id: getMockId(1),
+    objectType: OccupationEnums.Relations.Parent.ObjectTypes.ISCOGroup,
+  };
+
+  testSchemaWithValidObject(
+    "valid payload with ISCOGroup",
+    OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload,
+    validPayload
+  );
+
+  testSchemaWithValidObject(
+    "valid payload with LocalGroup",
+    OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload,
+    {
+      id: getMockId(2),
+      objectType: OccupationEnums.Relations.Parent.ObjectTypes.LocalGroup,
+    }
+  );
+
+  testSchemaWithValidObject(
+    "valid payload with ESCOOccupation",
+    OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload,
+    {
+      id: getMockId(3),
+      objectType: OccupationEnums.Relations.Parent.ObjectTypes.ESCOOccupation,
+    }
+  );
+
+  testSchemaWithValidObject(
+    "valid payload with LocalOccupation",
+    OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload,
+    {
+      id: getMockId(4),
+      objectType: OccupationEnums.Relations.Parent.ObjectTypes.LocalOccupation,
+    }
+  );
+
+  testSchemaWithAdditionalProperties(
+    "payload with additional properties",
+    OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload,
+    {
+      ...validPayload,
+      extraProperty: "extra test property (not defined in schema) for testing additionalProperties",
+    }
+  );
+
+  describe("OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload fields", () => {
+    describe("Test validation of 'id'", () => {
+      const testCases = getStdObjectIdTestCases("/id");
+      test.each(testCases)("%s Validate 'id' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+        assertCaseForProperty(
+          "id",
+          { id: givenValue, objectType: OccupationEnums.Relations.Parent.ObjectTypes.ISCOGroup },
+          OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload,
+          caseType,
+          failureMessage
+        );
+      });
+    });
+
+    describe("Test validation of 'objectType'", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "undefined",
+          undefined,
+          constructSchemaError("", "required", "must have required property 'objectType'"),
+        ],
+        [CaseType.Failure, "null", null, constructSchemaError("/objectType", "type", "must be string")],
+        [CaseType.Failure, "boolean", true, constructSchemaError("/objectType", "type", "must be string")],
+        [CaseType.Failure, "number", 123, constructSchemaError("/objectType", "type", "must be string")],
+        [
+          CaseType.Failure,
+          "empty string",
+          "",
+          constructSchemaError("/objectType", "enum", "must be equal to one of the allowed values"),
+        ],
+        [
+          CaseType.Failure,
+          "only whitespace",
+          "   ",
+          constructSchemaError("/objectType", "enum", "must be equal to one of the allowed values"),
+        ],
+        [
+          CaseType.Failure,
+          "invalid value",
+          "invalid",
+          constructSchemaError("/objectType", "enum", "must be equal to one of the allowed values"),
+        ],
+        [
+          CaseType.Failure,
+          "wrong case",
+          "ISCOGroup",
+          constructSchemaError("/objectType", "enum", "must be equal to one of the allowed values"),
+        ],
+        [CaseType.Success, "ISCOGroup", OccupationEnums.Relations.Parent.ObjectTypes.ISCOGroup, undefined],
+        [CaseType.Success, "LocalGroup", OccupationEnums.Relations.Parent.ObjectTypes.LocalGroup, undefined],
+        [CaseType.Success, "ESCOOccupation", OccupationEnums.Relations.Parent.ObjectTypes.ESCOOccupation, undefined],
+        [CaseType.Success, "LocalOccupation", OccupationEnums.Relations.Parent.ObjectTypes.LocalOccupation, undefined],
+      ])("(%s) Validate 'objectType' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "objectType",
+          { id: getMockId(1), objectType: value },
+          OccupationAPISpecs.Occupation.Parent.POST.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+  });
+});

--- a/api-specifications/src/esco/occupation/[id]/parent/POST/schema.response.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/parent/POST/schema.response.test.ts
@@ -1,0 +1,307 @@
+import {
+  testSchemaWithAdditionalProperties,
+  testSchemaWithValidObject,
+  testValidSchema,
+} from "_test_utilities/stdSchemaTests";
+import { CaseType, assertCaseForProperty, constructSchemaError } from "_test_utilities/assertCaseForProperty";
+import { getMockId } from "_test_utilities/mockMongoId";
+import { randomUUID } from "crypto";
+import { getTestString } from "../../../../../_test_utilities/specialCharacters";
+import OccupationAPISpecs from "../../../index";
+import OccupationEnums from "../../../_shared/enums";
+import OccupationGroupEnums from "../../../../occupationGroup/_shared/enums";
+import {
+  getTestISCOGroupCode,
+  getTestESCOOccupationCode,
+  getTestLocalOccupationCode,
+} from "../../../../_test_utilities/testUtils";
+
+describe("OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload schema", () => {
+  testValidSchema(
+    "OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload",
+    OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload
+  );
+});
+
+describe("Test objects against the OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload schema", () => {
+  const givenParent = {
+    id: getMockId(1),
+    UUID: randomUUID(),
+    code: getTestISCOGroupCode(),
+    occupationGroupCode: getTestISCOGroupCode(),
+    preferredLabel: getTestString(20),
+    objectType: OccupationEnums.Relations.Parent.ObjectTypes.ISCOGroup,
+  };
+
+  const givenChild = {
+    id: getMockId(2),
+    UUID: randomUUID(),
+    code: getTestLocalOccupationCode(),
+    preferredLabel: getTestString(20),
+    objectType: OccupationEnums.Relations.Children.ObjectTypes.LocalOccupation,
+  };
+
+  const givenSkill = {
+    id: getMockId(3),
+    UUID: randomUUID(),
+    preferredLabel: getTestString(20),
+    isLocalized: true,
+    objectType: OccupationEnums.Relations.RequiredSkills.ObjectTypes.Skill,
+    relationType: OccupationEnums.OccupationToSkillRelationType.ESSENTIAL,
+    signallingValue: null,
+    signallingValueLabel: null,
+  };
+
+  const validOccupationResponse = {
+    id: getMockId(4),
+    UUID: randomUUID(),
+    UUIDHistory: [randomUUID()],
+    originUUID: randomUUID(),
+    code: getTestESCOOccupationCode(),
+    path: "https://path/to/tabiya",
+    tabiyaPath: "https://path/to/tabiya",
+    originUri: "https://foo/bar",
+    occupationGroupCode: getTestISCOGroupCode(),
+    description: getTestString(50),
+    preferredLabel: getTestString(20),
+    altLabels: [getTestString(15)],
+    definition: getTestString(50),
+    regulatedProfessionNote: getTestString(30),
+    scopeNote: getTestString(30),
+    occupationType: OccupationEnums.OccupationType.ESCOOccupation,
+    modelId: getMockId(5),
+    isLocalized: true,
+    parent: givenParent,
+    children: [givenChild],
+    requiresSkills: [givenSkill],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  const validOccupationGroupResponse = {
+    id: getMockId(6),
+    UUID: randomUUID(),
+    originUUID: randomUUID(),
+    UUIDHistory: [randomUUID()],
+    path: "https://path/to/tabiya",
+    tabiyaPath: "https://path/to/tabiya",
+    originUri: "https://foo/bar",
+    code: getTestISCOGroupCode(),
+    description: getTestString(50),
+    preferredLabel: getTestString(20),
+    altLabels: [getTestString(15)],
+    parent: null,
+    children: [],
+    groupType: OccupationGroupEnums.ObjectTypes.ISCOGroup,
+    modelId: getMockId(7),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  testSchemaWithValidObject(
+    "valid occupation response",
+    OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+    validOccupationResponse
+  );
+
+  testSchemaWithValidObject(
+    "valid occupation group response",
+    OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+    validOccupationGroupResponse
+  );
+
+  test("null response", () => {
+    assertCaseForProperty(
+      "",
+      null,
+      OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+      CaseType.Success,
+      undefined
+    );
+  });
+
+  testSchemaWithAdditionalProperties(
+    "occupation payload with additional properties",
+    OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+    {
+      ...validOccupationResponse,
+      extraProperty: "extra test property (not defined in schema) for testing additionalProperties",
+    }
+  );
+
+  testSchemaWithAdditionalProperties(
+    "occupation group payload with additional properties",
+    OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+    {
+      ...validOccupationGroupResponse,
+      extraProperty: "extra test property (not defined in schema) for testing additionalProperties",
+    }
+  );
+
+  describe("Invalid objects should not match anyOf", () => {
+    test("empty object should fail all branches", () => {
+      assertCaseForProperty(
+        "",
+        {},
+        OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+        CaseType.Failure,
+        constructSchemaError("", "anyOf", "must match a schema in anyOf")
+      );
+    });
+
+    test("string should fail all branches", () => {
+      assertCaseForProperty(
+        "",
+        "invalid",
+        OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+        CaseType.Failure,
+        constructSchemaError("", "anyOf", "must match a schema in anyOf")
+      );
+    });
+
+    test("number should fail all branches", () => {
+      assertCaseForProperty(
+        "",
+        123,
+        OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+        CaseType.Failure,
+        constructSchemaError("", "anyOf", "must match a schema in anyOf")
+      );
+    });
+  });
+
+  describe("Individual field validation on occupation response", () => {
+    describe("Test validation of 'id'", () => {
+      test.each([
+        [CaseType.Failure, "undefined", undefined, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [CaseType.Failure, "null", null, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [CaseType.Failure, "only whitespace", "   ", constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [CaseType.Failure, "random string", "foo", constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+      ])("%s Validate 'id' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+        const givenObject = {
+          ...validOccupationResponse,
+          id: givenValue,
+        };
+        assertCaseForProperty(
+          "id",
+          givenObject,
+          OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+          caseType,
+          failureMessage
+        );
+      });
+    });
+
+    describe("Test validation of 'occupationType'", () => {
+      test.each([
+        [CaseType.Failure, "undefined", undefined, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [CaseType.Failure, "null", null, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [
+          CaseType.Failure,
+          "invalid value",
+          "invalid",
+          constructSchemaError("", "anyOf", "must match a schema in anyOf"),
+        ],
+      ])("%s Validate 'occupationType' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+        const givenObject = {
+          ...validOccupationResponse,
+          occupationType: givenValue,
+        };
+        assertCaseForProperty(
+          "occupationType",
+          givenObject,
+          OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+          caseType,
+          failureMessage
+        );
+      });
+    });
+
+    describe("Test validation of 'code'", () => {
+      test.each([
+        [CaseType.Failure, "undefined", undefined, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [CaseType.Failure, "null", null, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [CaseType.Failure, "empty string", "", constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+      ])("%s Validate 'code' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+        const givenObject = {
+          ...validOccupationResponse,
+          code: givenValue,
+        };
+        assertCaseForProperty(
+          "code",
+          givenObject,
+          OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+          caseType,
+          failureMessage
+        );
+      });
+    });
+
+    describe("Test validation of 'isLocalized'", () => {
+      test.each([
+        [CaseType.Failure, "undefined", undefined, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [CaseType.Failure, "null", null, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [CaseType.Failure, "string", "true", constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+      ])("%s Validate 'isLocalized' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+        const givenObject = {
+          ...validOccupationResponse,
+          isLocalized: givenValue,
+        };
+        assertCaseForProperty(
+          "isLocalized",
+          givenObject,
+          OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+          caseType,
+          failureMessage
+        );
+      });
+    });
+  });
+
+  describe("Individual field validation on occupation group response", () => {
+    describe("Test validation of 'groupType'", () => {
+      test.each([
+        [CaseType.Failure, "undefined", undefined, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [CaseType.Failure, "null", null, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [
+          CaseType.Failure,
+          "invalid value",
+          "invalid",
+          constructSchemaError("", "anyOf", "must match a schema in anyOf"),
+        ],
+      ])("%s Validate 'groupType' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+        const givenObject = {
+          ...validOccupationGroupResponse,
+          groupType: givenValue,
+        };
+        assertCaseForProperty(
+          "groupType",
+          givenObject,
+          OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+          caseType,
+          failureMessage
+        );
+      });
+    });
+
+    describe("Test validation of 'id'", () => {
+      test.each([
+        [CaseType.Failure, "undefined", undefined, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [CaseType.Failure, "null", null, constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+        [CaseType.Failure, "random string", "foo", constructSchemaError("", "anyOf", "must match a schema in anyOf")],
+      ])("%s Validate 'id' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+        const givenObject = {
+          ...validOccupationGroupResponse,
+          id: givenValue,
+        };
+        assertCaseForProperty(
+          "id",
+          givenObject,
+          OccupationAPISpecs.Occupation.Parent.POST.Schemas.Response.Payload,
+          caseType,
+          failureMessage
+        );
+      });
+    });
+  });
+});

--- a/api-specifications/src/esco/occupation/[id]/parent/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/esco/occupation/[id]/parent/__snapshots__/index.test.ts.snap
@@ -6,6 +6,7 @@ exports[`Test the Occupation Parent Instance Detail module The export module mat
     "ALT_LABELS_MAX_ITEMS": 100,
     "ALT_LABEL_MAX_LENGTH": 256,
     "CODE_MAX_LENGTH": 256,
+    "CODE_PATTERN_MAX_LENGTH": 100,
     "DEFAULT_LIMIT": 10,
     "DEFINITION_MAX_LENGTH": 4000,
     "DESCRIPTION_MAX_LENGTH": 6000,

--- a/api-specifications/src/esco/occupation/[id]/skills/POST/schema.request.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/skills/POST/schema.request.test.ts
@@ -1,0 +1,175 @@
+import {
+  testSchemaWithAdditionalProperties,
+  testSchemaWithValidObject,
+  testValidSchema,
+} from "_test_utilities/stdSchemaTests";
+import { CaseType, assertCaseForProperty, constructSchemaError } from "_test_utilities/assertCaseForProperty";
+import { getMockId } from "_test_utilities/mockMongoId";
+import { getStdObjectIdTestCases } from "_test_utilities/stdSchemaTestCases";
+import OccupationAPISpecs from "../../../index";
+import OccupationEnums from "../../../_shared/enums";
+import OccupationConstants from "../../../_shared/constants";
+import { SignallingValueLabel } from "../../../../common/objectTypes";
+
+describe("OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload schema", () => {
+  testValidSchema(
+    "OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload
+  );
+});
+
+describe("Test objects against the OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload schema", () => {
+  const validPayload = {
+    requiredSkillId: getMockId(1),
+    relationType: OccupationEnums.OccupationToSkillRelationType.ESSENTIAL,
+    signallingValueLabel: SignallingValueLabel.HIGH,
+    signallingValue: 50,
+  };
+
+  testSchemaWithValidObject(
+    "valid payload with all fields",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload,
+    validPayload
+  );
+
+  testSchemaWithValidObject(
+    "valid payload with only requiredSkillId",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload,
+    { requiredSkillId: getMockId(2) }
+  );
+
+  testSchemaWithValidObject(
+    "valid payload with null signallingValue",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload,
+    { ...validPayload, signallingValue: null }
+  );
+
+  testSchemaWithValidObject(
+    "valid payload with ESCO relationType only",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload,
+    { requiredSkillId: getMockId(1), relationType: OccupationEnums.OccupationToSkillRelationType.ESSENTIAL }
+  );
+
+  testSchemaWithValidObject(
+    "valid payload with signalling values only",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload,
+    {
+      requiredSkillId: getMockId(1),
+      signallingValueLabel: SignallingValueLabel.LOW,
+      signallingValue: 25,
+    }
+  );
+
+  testSchemaWithAdditionalProperties(
+    "payload with additional properties",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload,
+    {
+      ...validPayload,
+      extraProperty: "extra test property (not defined in schema) for testing additionalProperties",
+    }
+  );
+
+  describe("OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload fields", () => {
+    describe("Test validation of 'requiredSkillId'", () => {
+      const testCases = getStdObjectIdTestCases("/requiredSkillId");
+      test.each(testCases)(
+        "%s Validate 'requiredSkillId' when it is %s",
+        (caseType, _description, givenValue, failureMessage) => {
+          assertCaseForProperty(
+            "requiredSkillId",
+            { requiredSkillId: givenValue },
+            OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload,
+            caseType,
+            failureMessage
+          );
+        }
+      );
+    });
+
+    describe("Test validation of 'relationType'", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/relationType", "type", "must be string")],
+        [CaseType.Failure, "boolean", true, constructSchemaError("/relationType", "type", "must be string")],
+        [CaseType.Failure, "number", 123, constructSchemaError("/relationType", "type", "must be string")],
+        [CaseType.Success, "empty string (NONE)", OccupationEnums.OccupationToSkillRelationType.NONE, undefined],
+        [CaseType.Success, "essential", OccupationEnums.OccupationToSkillRelationType.ESSENTIAL, undefined],
+        [CaseType.Success, "optional", OccupationEnums.OccupationToSkillRelationType.OPTIONAL, undefined],
+        [
+          CaseType.Failure,
+          "invalid value",
+          "invalid",
+          constructSchemaError("/relationType", "enum", "must be equal to one of the allowed values"),
+        ],
+      ])("(%s) Validate 'relationType' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "relationType",
+          { requiredSkillId: getMockId(1), relationType: value },
+          OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of 'signallingValueLabel'", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Failure, "null", null, constructSchemaError("/signallingValueLabel", "type", "must be string")],
+        [CaseType.Failure, "boolean", false, constructSchemaError("/signallingValueLabel", "type", "must be string")],
+        [CaseType.Failure, "number", 99, constructSchemaError("/signallingValueLabel", "type", "must be string")],
+        [CaseType.Success, "empty string (NONE)", SignallingValueLabel.NONE, undefined],
+        [CaseType.Success, "high", SignallingValueLabel.HIGH, undefined],
+        [CaseType.Success, "medium", SignallingValueLabel.MEDIUM, undefined],
+        [CaseType.Success, "low", SignallingValueLabel.LOW, undefined],
+        [
+          CaseType.Failure,
+          "invalid value",
+          "invalid",
+          constructSchemaError("/signallingValueLabel", "enum", "must be equal to one of the allowed values"),
+        ],
+      ])("(%s) Validate 'signallingValueLabel' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "signallingValueLabel",
+          { requiredSkillId: getMockId(1), signallingValueLabel: value },
+          OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+
+    describe("Test validation of 'signallingValue'", () => {
+      test.each([
+        [CaseType.Success, "undefined", undefined, undefined],
+        [CaseType.Success, "null", null, undefined],
+        [CaseType.Failure, "string", "foo", constructSchemaError("/signallingValue", "type", "must be number,null")],
+        [CaseType.Failure, "boolean", true, constructSchemaError("/signallingValue", "type", "must be number,null")],
+        [CaseType.Failure, "array", [1], constructSchemaError("/signallingValue", "type", "must be number,null")],
+        [
+          CaseType.Failure,
+          "below minimum",
+          OccupationConstants.SIGNALLING_VALUE_MIN - 1,
+          constructSchemaError("/signallingValue", "minimum", `must be >= ${OccupationConstants.SIGNALLING_VALUE_MIN}`),
+        ],
+        [
+          CaseType.Failure,
+          "above maximum",
+          OccupationConstants.SIGNALLING_VALUE_MAX + 1,
+          constructSchemaError("/signallingValue", "maximum", `must be <= ${OccupationConstants.SIGNALLING_VALUE_MAX}`),
+        ],
+        [CaseType.Success, "minimum", OccupationConstants.SIGNALLING_VALUE_MIN, undefined],
+        [CaseType.Success, "maximum", OccupationConstants.SIGNALLING_VALUE_MAX, undefined],
+        [CaseType.Success, "mid range", 50, undefined],
+      ])("(%s) Validate 'signallingValue' when it is %s", (caseType, _desc, value, failure) => {
+        assertCaseForProperty(
+          "signallingValue",
+          { requiredSkillId: getMockId(1), signallingValue: value },
+          OccupationAPISpecs.Occupation.Skills.POST.Schemas.Request.Payload,
+          caseType,
+          failure
+        );
+      });
+    });
+  });
+});

--- a/api-specifications/src/esco/occupation/[id]/skills/POST/schema.response.test.ts
+++ b/api-specifications/src/esco/occupation/[id]/skills/POST/schema.response.test.ts
@@ -1,0 +1,494 @@
+import {
+  testSchemaWithAdditionalProperties,
+  testSchemaWithValidObject,
+  testValidSchema,
+  testObjectIdField,
+  testNonEmptyStringField,
+  testStringField,
+  testUUIDField,
+  testUUIDArray,
+  testNonEmptyURIStringField,
+  testTimestampField,
+  testURIField,
+  testBooleanField,
+} from "_test_utilities/stdSchemaTests";
+import { CaseType, assertCaseForProperty, constructSchemaError } from "_test_utilities/assertCaseForProperty";
+import { getMockId } from "_test_utilities/mockMongoId";
+import { randomUUID } from "crypto";
+import { getTestString } from "../../../../../_test_utilities/specialCharacters";
+import {
+  getStdNonEmptyStringTestCases,
+  getStdObjectIdTestCases,
+  getStdUUIDTestCases,
+} from "_test_utilities/stdSchemaTestCases";
+import OccupationAPISpecs from "../../../index";
+import OccupationEnums from "../../../_shared/enums";
+import OccupationConstants from "../../../_shared/constants";
+import SkillConstants from "../../../../skill/_shared/constants";
+import SkillEnums from "../../../../skill/_shared/enums";
+import { getTestSkillGroupCode } from "../../../../_test_utilities/testUtils";
+
+describe("OccupationAPISpecs.Occupation.Skills.POST.Schemas.Response.Payload schema", () => {
+  testValidSchema(
+    "OccupationAPISpecs.Occupation.Skills.POST.Schemas.Response.Payload",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Response.Payload
+  );
+});
+
+describe("Test objects against the OccupationAPISpecs.Occupation.Skills.POST.Schemas.Response.Payload schema", () => {
+  const givenParent = {
+    id: getMockId(2),
+    UUID: randomUUID(),
+    preferredLabel: getTestString(SkillConstants.PREFERRED_LABEL_MAX_LENGTH),
+    objectType: SkillEnums.ObjectTypes.SkillGroup,
+    code: getTestSkillGroupCode(),
+  };
+
+  const givenChild = {
+    id: getMockId(3),
+    UUID: randomUUID(),
+    preferredLabel: getTestString(SkillConstants.PREFERRED_LABEL_MAX_LENGTH),
+    objectType: SkillEnums.ObjectTypes.Skill,
+    isLocalized: true,
+  };
+
+  const givenValidSkill = {
+    id: getMockId(1),
+    UUID: randomUUID(),
+    UUIDHistory: [randomUUID()],
+    originUUID: randomUUID(),
+    path: "https://path/to/tabiya",
+    tabiyaPath: "https://path/to/tabiya",
+    preferredLabel: getTestString(20),
+    originUri: "https://foo/bar",
+    altLabels: [getTestString(15)],
+    definition: getTestString(50),
+    description: getTestString(50),
+    scopeNote: getTestString(30),
+    skillType: SkillEnums.SkillType.SkillCompetence,
+    reuseLevel: SkillEnums.ReuseLevel.CrossSector,
+    modelId: getMockId(1),
+    isLocalized: true,
+    parents: [givenParent],
+    children: [givenChild],
+    requiresSkills: [],
+    requiredBySkills: [],
+    requiredByOccupations: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    relationType: OccupationEnums.OccupationToSkillRelationType.ESSENTIAL,
+    signallingValue: 50,
+    signallingValueLabel: getTestString(20),
+  };
+
+  testSchemaWithValidObject(
+    "valid skill response with all fields",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Response.Payload,
+    givenValidSkill
+  );
+
+  testSchemaWithValidObject(
+    "valid skill response with null relationship metadata",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Response.Payload,
+    { ...givenValidSkill, relationType: null, signallingValue: null, signallingValueLabel: null }
+  );
+
+  testSchemaWithValidObject(
+    "valid skill response with empty arrays",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Response.Payload,
+    {
+      ...givenValidSkill,
+      parents: [],
+      children: [],
+      altLabels: [],
+      requiresSkills: [],
+      requiredBySkills: [],
+      requiredByOccupations: [],
+      UUIDHistory: [],
+    }
+  );
+
+  testSchemaWithAdditionalProperties(
+    "payload with additional properties",
+    OccupationAPISpecs.Occupation.Skills.POST.Schemas.Response.Payload,
+    {
+      ...givenValidSkill,
+      extraProperty: "extra test property (not defined in schema) for testing additionalProperties",
+    }
+  );
+
+  describe("OccupationAPISpecs.Occupation.Skills.POST.Schemas.Response.Payload fields", () => {
+    const itemSchema = OccupationAPISpecs.Occupation.Skills.POST.Schemas.Response.Payload;
+
+    describe("Test validation of inherited skill fields", () => {
+      describe("Test validation of 'id'", () => {
+        testObjectIdField("id", itemSchema);
+      });
+
+      describe("Test validation of 'UUID'", () => {
+        testUUIDField("UUID", itemSchema);
+      });
+
+      describe("Test validation of 'originUUID'", () => {
+        testUUIDField("originUUID", itemSchema);
+      });
+
+      describe("Test validation of 'UUIDHistory'", () => {
+        testUUIDArray("UUIDHistory", itemSchema, [], true, true);
+      });
+
+      describe("Test validation of 'path'", () => {
+        testURIField("path", SkillConstants.PATH_URI_MAX_LENGTH, itemSchema);
+      });
+
+      describe("Test validation of 'tabiyaPath'", () => {
+        testURIField("tabiyaPath", SkillConstants.TABIYA_PATH_URI_MAX_LENGTH, itemSchema);
+      });
+
+      describe("Test validation of 'originUri'", () => {
+        testNonEmptyURIStringField("originUri", SkillConstants.ORIGIN_URI_MAX_LENGTH, itemSchema);
+      });
+
+      describe("Test validation of 'preferredLabel'", () => {
+        testNonEmptyStringField("preferredLabel", SkillConstants.PREFERRED_LABEL_MAX_LENGTH, itemSchema);
+      });
+
+      describe("Test validation of 'description'", () => {
+        testStringField("description", SkillConstants.DESCRIPTION_MAX_LENGTH, itemSchema);
+      });
+
+      describe("Test validation of 'definition'", () => {
+        testStringField("definition", SkillConstants.DEFINITION_MAX_LENGTH, itemSchema);
+      });
+
+      describe("Test validation of 'scopeNote'", () => {
+        testStringField("scopeNote", SkillConstants.SCOPE_NOTE_MAX_LENGTH, itemSchema);
+      });
+
+      describe("Test validation of 'altLabels'", () => {
+        test.each([
+          [
+            CaseType.Failure,
+            "undefined",
+            undefined,
+            constructSchemaError("", "required", "must have required property 'altLabels'"),
+          ],
+          [CaseType.Failure, "null", null, constructSchemaError("/altLabels", "type", "must be array")],
+          [CaseType.Failure, "empty string", "", constructSchemaError("/altLabels", "type", "must be array")],
+          [
+            CaseType.Failure,
+            "array of objects",
+            [{}, {}],
+            [
+              constructSchemaError("/altLabels/0", "type", "must be string"),
+              constructSchemaError("/altLabels/1", "type", "must be string"),
+            ],
+          ],
+          [CaseType.Success, "empty array", [], undefined],
+          [CaseType.Success, "valid array", [getTestString(15), getTestString(20)], undefined],
+        ])("(%s) Validate 'altLabels' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+          const givenObject = { altLabels: givenValue };
+          assertCaseForProperty("altLabels", givenObject, itemSchema, caseType, failureMessage);
+        });
+      });
+
+      describe("Test validation of 'skillType'", () => {
+        test.each([
+          [
+            CaseType.Failure,
+            "undefined",
+            undefined,
+            constructSchemaError("", "required", "must have required property 'skillType'"),
+          ],
+          [CaseType.Failure, "null", null, constructSchemaError("/skillType", "type", "must be string")],
+          [
+            CaseType.Failure,
+            "invalid value",
+            "invalid",
+            constructSchemaError("/skillType", "enum", "must be equal to one of the allowed values"),
+          ],
+          [CaseType.Success, "skill/competence", SkillEnums.SkillType.SkillCompetence, undefined],
+          [CaseType.Success, "knowledge", SkillEnums.SkillType.Knowledge, undefined],
+          [CaseType.Success, "language", SkillEnums.SkillType.Language, undefined],
+          [CaseType.Success, "attitude", SkillEnums.SkillType.Attitude, undefined],
+        ])("%s Validate 'skillType' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+          const givenObject = { ...givenValidSkill, skillType: givenValue };
+          assertCaseForProperty("skillType", givenObject, itemSchema, caseType, failureMessage);
+        });
+      });
+
+      describe("Test validation of 'reuseLevel'", () => {
+        test.each([
+          [
+            CaseType.Failure,
+            "undefined",
+            undefined,
+            constructSchemaError("", "required", "must have required property 'reuseLevel'"),
+          ],
+          [CaseType.Failure, "null", null, constructSchemaError("/reuseLevel", "type", "must be string")],
+          [
+            CaseType.Failure,
+            "invalid value",
+            "invalid",
+            constructSchemaError("/reuseLevel", "enum", "must be equal to one of the allowed values"),
+          ],
+          [CaseType.Success, "cross-sector", SkillEnums.ReuseLevel.CrossSector, undefined],
+          [CaseType.Success, "sector-specific", SkillEnums.ReuseLevel.SectorSpecific, undefined],
+          [CaseType.Success, "occupation-specific", SkillEnums.ReuseLevel.OccupationSpecific, undefined],
+        ])("%s Validate 'reuseLevel' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+          const givenObject = { ...givenValidSkill, reuseLevel: givenValue };
+          assertCaseForProperty("reuseLevel", givenObject, itemSchema, caseType, failureMessage);
+        });
+      });
+
+      describe("Test validation of 'modelId'", () => {
+        testObjectIdField("modelId", itemSchema);
+      });
+
+      describe("Test validation of 'isLocalized'", () => {
+        testBooleanField("isLocalized", itemSchema);
+      });
+    });
+
+    describe("Test validation of relationship metadata fields", () => {
+      describe("Test validation of 'relationType'", () => {
+        test.each([
+          [CaseType.Success, "null", null, undefined],
+          [CaseType.Success, "essential", OccupationEnums.OccupationToSkillRelationType.ESSENTIAL, undefined],
+          [CaseType.Success, "optional", OccupationEnums.OccupationToSkillRelationType.OPTIONAL, undefined],
+          [
+            CaseType.Failure,
+            "invalid string",
+            "invalid",
+            constructSchemaError("/relationType", "enum", "must be equal to one of the allowed values"),
+          ],
+        ])("%s Validate 'relationType' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+          const givenObject = {
+            ...givenValidSkill,
+            relationType: givenValue,
+          };
+          assertCaseForProperty("relationType", givenObject, itemSchema, caseType, failureMessage);
+        });
+      });
+
+      describe("Test validation of 'signallingValue'", () => {
+        test.each([
+          [CaseType.Success, "null", null, undefined],
+          [CaseType.Success, "valid number", 50, undefined],
+          [CaseType.Success, "minimum", OccupationConstants.SIGNALLING_VALUE_MIN, undefined],
+          [CaseType.Success, "maximum", OccupationConstants.SIGNALLING_VALUE_MAX, undefined],
+          [
+            CaseType.Failure,
+            "below minimum",
+            OccupationConstants.SIGNALLING_VALUE_MIN - 1,
+            constructSchemaError(
+              "/signallingValue",
+              "minimum",
+              `must be >= ${OccupationConstants.SIGNALLING_VALUE_MIN}`
+            ),
+          ],
+          [
+            CaseType.Failure,
+            "above maximum",
+            OccupationConstants.SIGNALLING_VALUE_MAX + 1,
+            constructSchemaError(
+              "/signallingValue",
+              "maximum",
+              `must be <= ${OccupationConstants.SIGNALLING_VALUE_MAX}`
+            ),
+          ],
+        ])("%s Validate 'signallingValue' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+          const givenObject = {
+            ...givenValidSkill,
+            signallingValue: givenValue,
+          };
+          assertCaseForProperty("signallingValue", givenObject, itemSchema, caseType, failureMessage);
+        });
+      });
+
+      describe("Test validation of 'signallingValueLabel'", () => {
+        test.each([
+          [CaseType.Success, "null", null, undefined],
+          [CaseType.Success, "valid string", getTestString(20), undefined],
+          [
+            CaseType.Failure,
+            "only whitespace",
+            "   ",
+            constructSchemaError("/signallingValueLabel", "pattern", `must match pattern "\\S"`),
+          ],
+          [
+            CaseType.Failure,
+            "too long",
+            getTestString(OccupationConstants.SIGNALLING_VALUE_LABEL_MAX_LENGTH + 1),
+            constructSchemaError(
+              "/signallingValueLabel",
+              "maxLength",
+              `must NOT have more than ${OccupationConstants.SIGNALLING_VALUE_LABEL_MAX_LENGTH} characters`
+            ),
+          ],
+        ])("%s Validate 'signallingValueLabel' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+          const givenObject = {
+            ...givenValidSkill,
+            signallingValueLabel: givenValue,
+          };
+          assertCaseForProperty("signallingValueLabel", givenObject, itemSchema, caseType, failureMessage);
+        });
+      });
+    });
+
+    describe("Test validation of 'parents' field", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "undefined",
+          undefined,
+          constructSchemaError("", "required", "must have required property 'parents'"),
+        ],
+        [CaseType.Failure, "null", null, constructSchemaError("/parents", "type", "must be array")],
+        [CaseType.Success, "empty array", [], undefined],
+        [CaseType.Success, "valid parents", [givenParent], undefined],
+      ])("%s Validate 'parents' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+        const givenObject = {
+          ...givenValidSkill,
+          parents: givenValue,
+        };
+        assertCaseForProperty("parents", givenObject, itemSchema, caseType, failureMessage);
+      });
+    });
+
+    describe("Test validation of parents nested fields", () => {
+      describe("Test validation of 'parents/0/id'", () => {
+        const testCases = getStdObjectIdTestCases("/parents/0/id");
+        test.each(testCases)(
+          `(%s) Validate 'id' when it is %s`,
+          (caseType, _description, givenValue, failureMessages) => {
+            const givenObject = {
+              ...givenValidSkill,
+              parents: [{ ...givenParent, id: givenValue }],
+            };
+            assertCaseForProperty("/parents/0/id", givenObject, itemSchema, caseType, failureMessages);
+          }
+        );
+      });
+
+      describe("Test validation of 'parents/0/UUID'", () => {
+        const testCases = getStdUUIDTestCases("/parents/0/UUID");
+        test.each(testCases)(
+          `(%s) Validate 'UUID' when it is %s`,
+          (caseType, _description, givenValue, failureMessages) => {
+            const givenObject = {
+              ...givenValidSkill,
+              parents: [{ ...givenParent, UUID: givenValue }],
+            };
+            assertCaseForProperty("/parents/0/UUID", givenObject, itemSchema, caseType, failureMessages);
+          }
+        );
+      });
+
+      describe("Test validation of 'parents/0/preferredLabel'", () => {
+        const testCases = getStdNonEmptyStringTestCases(
+          "/parents/0/preferredLabel",
+          SkillConstants.PREFERRED_LABEL_MAX_LENGTH
+        );
+        test.each(testCases)(
+          `(%s) Validate 'preferredLabel' when it is %s`,
+          (caseType, _description, givenValue, failureMessage) => {
+            const givenObject = {
+              ...givenValidSkill,
+              parents: [{ ...givenParent, preferredLabel: givenValue }],
+            };
+            assertCaseForProperty("/parents/0/preferredLabel", givenObject, itemSchema, caseType, failureMessage);
+          }
+        );
+      });
+    });
+
+    describe("Test validation of 'children' field", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "undefined",
+          undefined,
+          constructSchemaError("", "required", "must have required property 'children'"),
+        ],
+        [CaseType.Failure, "null", null, constructSchemaError("/children", "type", "must be array")],
+        [CaseType.Success, "empty array", [], undefined],
+        [CaseType.Success, "valid children array", [givenChild], undefined],
+      ])("(%s) Validate 'children' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+        const givenObject = {
+          ...givenValidSkill,
+          children: givenValue,
+        };
+        assertCaseForProperty("children", givenObject, itemSchema, caseType, failureMessage);
+      });
+    });
+
+    describe("Test validation of 'requiresSkills' field", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "undefined",
+          undefined,
+          constructSchemaError("", "required", "must have required property 'requiresSkills'"),
+        ],
+        [CaseType.Failure, "null", null, constructSchemaError("/requiresSkills", "type", "must be array")],
+        [CaseType.Success, "empty array", [], undefined],
+      ])("(%s) Validate 'requiresSkills' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+        const givenObject = {
+          ...givenValidSkill,
+          requiresSkills: givenValue,
+        };
+        assertCaseForProperty("requiresSkills", givenObject, itemSchema, caseType, failureMessage);
+      });
+    });
+
+    describe("Test validation of 'requiredBySkills' field", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "undefined",
+          undefined,
+          constructSchemaError("", "required", "must have required property 'requiredBySkills'"),
+        ],
+        [CaseType.Failure, "null", null, constructSchemaError("/requiredBySkills", "type", "must be array")],
+        [CaseType.Success, "empty array", [], undefined],
+      ])("(%s) Validate 'requiredBySkills' when it is %s", (caseType, _description, givenValue, failureMessage) => {
+        const givenObject = {
+          ...givenValidSkill,
+          requiredBySkills: givenValue,
+        };
+        assertCaseForProperty("requiredBySkills", givenObject, itemSchema, caseType, failureMessage);
+      });
+    });
+
+    describe("Test validation of 'requiredByOccupations' field", () => {
+      test.each([
+        [
+          CaseType.Failure,
+          "undefined",
+          undefined,
+          constructSchemaError("", "required", "must have required property 'requiredByOccupations'"),
+        ],
+        [CaseType.Failure, "null", null, constructSchemaError("/requiredByOccupations", "type", "must be array")],
+        [CaseType.Success, "empty array", [], undefined],
+      ])(
+        "(%s) Validate 'requiredByOccupations' when it is %s",
+        (caseType, _description, givenValue, failureMessage) => {
+          const givenObject = {
+            ...givenValidSkill,
+            requiredByOccupations: givenValue,
+          };
+          assertCaseForProperty("requiredByOccupations", givenObject, itemSchema, caseType, failureMessage);
+        }
+      );
+    });
+
+    describe("Test validation of 'createdAt'", () => {
+      testTimestampField("createdAt", itemSchema);
+    });
+
+    describe("Test validation of 'updatedAt'", () => {
+      testTimestampField("updatedAt", itemSchema);
+    });
+  });
+});

--- a/api-specifications/src/esco/occupation/[id]/skills/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/esco/occupation/[id]/skills/__snapshots__/index.test.ts.snap
@@ -6,6 +6,7 @@ exports[`Test the Occupation Skills Instance Detail module The export module mat
     "ALT_LABELS_MAX_ITEMS": 100,
     "ALT_LABEL_MAX_LENGTH": 256,
     "CODE_MAX_LENGTH": 256,
+    "CODE_PATTERN_MAX_LENGTH": 100,
     "DEFAULT_LIMIT": 10,
     "DEFINITION_MAX_LENGTH": 4000,
     "DESCRIPTION_MAX_LENGTH": 6000,

--- a/api-specifications/src/esco/occupation/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/esco/occupation/__snapshots__/index.test.ts.snap
@@ -6,6 +6,7 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
     "ALT_LABELS_MAX_ITEMS": 100,
     "ALT_LABEL_MAX_LENGTH": 256,
     "CODE_MAX_LENGTH": 256,
+    "CODE_PATTERN_MAX_LENGTH": 100,
     "DEFAULT_LIMIT": 10,
     "DEFINITION_MAX_LENGTH": 4000,
     "DESCRIPTION_MAX_LENGTH": 6000,
@@ -768,6 +769,7 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
         "ALT_LABELS_MAX_ITEMS": 100,
         "ALT_LABEL_MAX_LENGTH": 256,
         "CODE_MAX_LENGTH": 256,
+        "CODE_PATTERN_MAX_LENGTH": 100,
         "DEFAULT_LIMIT": 10,
         "DEFINITION_MAX_LENGTH": 4000,
         "DESCRIPTION_MAX_LENGTH": 6000,
@@ -1495,6 +1497,7 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
       "ALT_LABELS_MAX_ITEMS": 100,
       "ALT_LABEL_MAX_LENGTH": 256,
       "CODE_MAX_LENGTH": 256,
+      "CODE_PATTERN_MAX_LENGTH": 100,
       "DEFAULT_LIMIT": 10,
       "DEFINITION_MAX_LENGTH": 4000,
       "DESCRIPTION_MAX_LENGTH": 6000,
@@ -1577,29 +1580,10 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
         },
       },
     },
-    "History": {
+    "PATCH": {
       "Constants": {
-        "ALT_LABELS_MAX_ITEMS": 100,
-        "ALT_LABEL_MAX_LENGTH": 256,
-        "CODE_MAX_LENGTH": 256,
-        "DEFAULT_LIMIT": 10,
-        "DEFINITION_MAX_LENGTH": 4000,
-        "DESCRIPTION_MAX_LENGTH": 6000,
-        "MAX_CURSOR_LENGTH": 1024,
-        "MAX_LIMIT": 100,
-        "MAX_PAYLOAD_LENGTH": 1000,
-        "OCCUPATION_GROUP_CODE_MAX_LENGTH": 256,
-        "ORIGIN_URI_MAX_LENGTH": 4096,
-        "PATH_URI_MAX_LENGTH": 4096,
-        "PREFERRED_LABEL_MAX_LENGTH": 256,
-        "REGULATED_PROFESSION_NOTE_MAX_LENGTH": 4000,
-        "SCOPE_NOTE_MAX_LENGTH": 4000,
-        "SIGNALLING_VALUE_LABEL_MAX_LENGTH": 256,
-        "SIGNALLING_VALUE_MAX": 100,
-        "SIGNALLING_VALUE_MIN": 0,
-        "TABIYA_PATH_URI_MAX_LENGTH": 4096,
-        "UUID_HISTORY_MAX_ITEMS": 10000,
-        "UUID_HISTORY_MAX_LENGTH": 50,
+        "MAX_JSON_OVERHEAD": 10000,
+        "MAX_PATCH_PAYLOAD_LENGTH": 566656,
       },
       "Enums": {
         "OccupationToSkillRelationType": {
@@ -1635,116 +1619,1510 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
           },
         },
       },
-      "GET": {
-        "Errors": {
-          "Status400": {
-            "ErrorCodes": {
-              "INVALID_OCCUPATION_ID": "INVALID_OCCUPATION_ID",
-            },
-          },
-          "Status404": {
-            "ErrorCodes": {
-              "MODEL_NOT_FOUND": "MODEL_NOT_FOUND",
-              "OCCUPATION_NOT_FOUND": "OCCUPATION_NOT_FOUND",
-            },
-          },
-          "Status500": {
-            "ErrorCodes": {
-              "DB_FAILED_TO_RETRIEVE_OCCUPATION_HISTORY": "DB_FAILED_TO_RETRIEVE_OCCUPATION_HISTORY",
-            },
+      "Errors": {
+        "Status400": {
+          "ErrorCodes": {
+            "INVALID_MODEL_ID": "INVALID_MODEL_ID",
+            "OCCUPATION_COULD_NOT_VALIDATE": "OCCUPATION_COULD_NOT_VALIDATE",
+            "UNABLE_TO_ALTER_RELEASED_MODEL": "UNABLE_TO_ALTER_RELEASED_MODEL",
           },
         },
-        "Schemas": {
-          "Response": {
-            "Payload": {
-              "$id": "/components/schemas/OccupationResponseSchemaGETHistory",
-              "items": {
+        "Status404": {
+          "ErrorCodes": {
+            "MODEL_NOT_FOUND": "MODEL_NOT_FOUND",
+            "OCCUPATION_NOT_FOUND": "OCCUPATION_NOT_FOUND",
+          },
+        },
+        "Status500": {
+          "ErrorCodes": {
+            "DB_FAILED_TO_UPDATE_OCCUPATION": "DB_FAILED_TO_UPDATE_OCCUPATION",
+          },
+        },
+      },
+      "Schemas": {
+        "Request": {
+          "Payload": {
+            "$id": "/components/schemas/OccupationRequestSchemaPATCH",
+            "additionalProperties": false,
+            "else": {
+              "properties": {
+                "code": {
+                  "maxLength": 100,
+                  "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                  "type": "string",
+                },
+                "occupationGroupCode": {
+                  "maxLength": 100,
+                  "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                  "type": "string",
+                },
+              },
+            },
+            "if": {
+              "properties": {
+                "occupationType": {
+                  "const": "escooccupation",
+                },
+              },
+            },
+            "properties": {
+              "UUIDHistory": {
+                "description": "The UUIDs history of the occupation.",
+                "items": {
+                  "maxLength": 50,
+                  "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                  "type": "string",
+                },
+                "maxItems": 10000,
+                "minItems": 0,
+                "type": "array",
+                "uniqueItems": true,
+              },
+              "altLabels": {
+                "description": "Alternative labels for the occupation.",
+                "items": {
+                  "maxLength": 256,
+                  "type": "string",
+                },
+                "maxItems": 100,
+                "minItems": 0,
+                "type": "array",
+                "uniqueItems": true,
+              },
+              "code": {
+                "description": "The code of the occupation.",
+                "maxLength": 256,
+                "type": "string",
+              },
+              "definition": {
+                "description": "The formal definition of the occupation.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+              "description": {
+                "description": "Additional descriptive information about the occupation.",
+                "maxLength": 6000,
+                "type": "string",
+              },
+              "isLocalized": {
+                "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
+                "type": "boolean",
+              },
+              "modelId": {
+                "description": "The identifier of the model containing this occupation.",
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string",
+              },
+              "occupationGroupCode": {
+                "description": "The code of the parent occupation group.",
+                "maxLength": 256,
+                "type": "string",
+              },
+              "occupationType": {
+                "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
+                "enum": [
+                  "escooccupation",
+                  "localoccupation",
+                ],
+                "type": "string",
+              },
+              "originUri": {
+                "description": "The origin URI of the occupation.",
+                "format": "uri",
+                "maxLength": 4096,
+                "pattern": "\\S",
+                "type": "string",
+              },
+              "preferredLabel": {
+                "description": "The preferred label of the occupation.",
+                "maxLength": 256,
+                "pattern": "\\S",
+                "type": "string",
+              },
+              "regulatedProfessionNote": {
+                "description": "Regulatory information for legally regulated professions.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+              "scopeNote": {
+                "description": "Scope clarification for the occupation's application.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+            },
+            "then": {
+              "properties": {
+                "code": {
+                  "maxLength": 100,
+                  "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                  "type": "string",
+                },
+                "occupationGroupCode": {
+                  "maxLength": 100,
+                  "pattern": "^\\d{1,4}$",
+                  "type": "string",
+                },
+              },
+            },
+            "type": "object",
+          },
+        },
+        "Response": {
+          "Payload": {
+            "$id": "/components/schemas/OccupationResponseSchemaPATCH",
+            "additionalProperties": false,
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "occupationType": {
+                      "const": "escooccupation",
+                    },
+                  },
+                },
+                "then": {
+                  "properties": {
+                    "code": {
+                      "maxLength": 256,
+                      "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                      "type": "string",
+                    },
+                    "occupationGroupCode": {
+                      "maxLength": 256,
+                      "pattern": "^\\d{1,4}$",
+                      "type": "string",
+                    },
+                  },
+                },
+              },
+              {
+                "if": {
+                  "properties": {
+                    "occupationType": {
+                      "const": "localoccupation",
+                    },
+                  },
+                },
+                "then": {
+                  "properties": {
+                    "code": {
+                      "maxLength": 256,
+                      "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                      "type": "string",
+                    },
+                    "occupationGroupCode": {
+                      "maxLength": 256,
+                      "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                      "type": "string",
+                    },
+                  },
+                },
+              },
+              {
+                "if": {
+                  "properties": {
+                    "occupationType": {
+                      "const": "escooccupation",
+                    },
+                  },
+                },
+                "then": {
+                  "properties": {
+                    "requiresSkills": {
+                      "items": {
+                        "properties": {
+                          "relationType": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "relationType",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                },
+              },
+              {
+                "if": {
+                  "properties": {
+                    "occupationType": {
+                      "const": "localoccupation",
+                    },
+                  },
+                },
+                "then": {
+                  "properties": {
+                    "requiresSkills": {
+                      "items": {
+                        "properties": {
+                          "signallingValue": {
+                            "type": "number",
+                          },
+                          "signallingValueLabel": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "signallingValue",
+                          "signallingValueLabel",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                },
+              },
+            ],
+            "properties": {
+              "UUID": {
+                "description": "The UUID of the occupation for cross-system identification.",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                "type": "string",
+              },
+              "UUIDHistory": {
+                "description": "The UUIDs history of the occupation.",
+                "items": {
+                  "maxLength": 50,
+                  "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                  "type": "string",
+                },
+                "maxItems": 10000,
+                "minItems": 0,
+                "type": "array",
+                "uniqueItems": true,
+              },
+              "altLabels": {
+                "description": "Alternative labels for the occupation.",
+                "items": {
+                  "maxLength": 256,
+                  "type": "string",
+                },
+                "maxItems": 100,
+                "minItems": 0,
+                "type": "array",
+                "uniqueItems": true,
+              },
+              "children": {
+                "description": "The children of this occupation.",
+                "items": {
+                  "additionalProperties": false,
+                  "allOf": [
+                    {
+                      "if": {
+                        "properties": {
+                          "objectType": {
+                            "const": "escooccupation",
+                          },
+                        },
+                      },
+                      "then": {
+                        "properties": {
+                          "code": {
+                            "maxLength": 256,
+                            "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                            "type": "string",
+                          },
+                          "occupationGroupCode": {
+                            "maxLength": 256,
+                            "pattern": "^\\d{1,4}$",
+                            "type": "string",
+                          },
+                        },
+                      },
+                    },
+                    {
+                      "if": {
+                        "properties": {
+                          "objectType": {
+                            "const": "localoccupation",
+                          },
+                        },
+                      },
+                      "then": {
+                        "properties": {
+                          "code": {
+                            "maxLength": 256,
+                            "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                            "type": "string",
+                          },
+                          "occupationGroupCode": {
+                            "maxLength": 256,
+                            "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                            "type": "string",
+                          },
+                        },
+                      },
+                    },
+                  ],
+                  "properties": {
+                    "UUID": {
+                      "description": "The UUID of the child occupation.",
+                      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                      "type": "string",
+                    },
+                    "code": {
+                      "description": "The code of the child occupation.",
+                      "maxLength": 256,
+                      "type": "string",
+                    },
+                    "id": {
+                      "description": "The id of the child occupation.",
+                      "pattern": "^[0-9a-f]{24}$",
+                      "type": "string",
+                    },
+                    "objectType": {
+                      "description": "The type of the occupation child (EscoOccupation or LocalOccupation).",
+                      "enum": [
+                        "escooccupation",
+                        "localoccupation",
+                      ],
+                      "type": "string",
+                    },
+                    "occupationGroupCode": {
+                      "description": "The code of the child occupation group.",
+                      "maxLength": 256,
+                      "type": "string",
+                    },
+                    "preferredLabel": {
+                      "description": "The preferred label of the child occupation.",
+                      "maxLength": 256,
+                      "pattern": "\\S",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+                "minItems": 0,
+                "type": "array",
+              },
+              "code": {
+                "description": "The code of the occupation.",
+                "maxLength": 256,
+                "type": "string",
+              },
+              "createdAt": {
+                "description": "Timestamp of record creation.",
+                "format": "date-time",
+                "type": "string",
+              },
+              "definition": {
+                "description": "The formal definition of the occupation.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+              "description": {
+                "description": "Additional descriptive information about the occupation.",
+                "maxLength": 6000,
+                "type": "string",
+              },
+              "id": {
+                "description": "The unique identifier of the occupation.",
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string",
+              },
+              "isLocalized": {
+                "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
+                "type": "boolean",
+              },
+              "modelId": {
+                "description": "The identifier of the model containing this occupation.",
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string",
+              },
+              "occupationGroupCode": {
+                "description": "The code of the parent occupation group.",
+                "maxLength": 256,
+                "type": "string",
+              },
+              "occupationType": {
+                "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
+                "enum": [
+                  "escooccupation",
+                  "localoccupation",
+                ],
+                "type": "string",
+              },
+              "originUUID": {
+                "description": "The original UUID of the occupation, i.e., the first UUID in UUIDHistory",
+                "maxLength": 50,
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                "type": "string",
+              },
+              "originUri": {
+                "description": "The origin URI of the occupation.",
+                "format": "uri",
+                "maxLength": 4096,
+                "pattern": "\\S",
+                "type": "string",
+              },
+              "parent": {
                 "additionalProperties": false,
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "iscogroup",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{1,4}$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{1,4}$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "localgroup",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "escooccupation",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{1,4}$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "localoccupation",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                ],
+                "description": "The parent occupation of this occupation.",
                 "properties": {
                   "UUID": {
-                    "description": "The UUID of the occupation.",
+                    "description": "The UUID of the occupation. It can be used to identify the parent occupation.",
                     "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
                     "type": "string",
                   },
                   "code": {
-                    "description": "The code of the occupation.",
+                    "description": "The code of the parent occupation.",
                     "maxLength": 256,
                     "type": "string",
                   },
                   "id": {
-                    "description": "The id of the occupation.",
+                    "description": "The id of the parent occupation.",
                     "pattern": "^[0-9a-f]{24}$",
                     "type": "string",
                   },
-                  "isLocalized": {
-                    "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
-                    "type": "boolean",
-                  },
-                  "model": {
-                    "$ref": "/components/schemas/ModelInfoReferenceSchema",
+                  "objectType": {
+                    "description": "The type of the occupation parent (LocalOccupation, ESCOOccupation, ISCOGroup or LocalGroup).",
+                    "enum": [
+                      "iscogroup",
+                      "localgroup",
+                      "escooccupation",
+                      "localoccupation",
+                    ],
+                    "type": "string",
                   },
                   "occupationGroupCode": {
                     "description": "The code of the parent occupation group.",
                     "maxLength": 256,
                     "type": "string",
                   },
-                  "occupationType": {
-                    "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
-                    "enum": [
-                      "escooccupation",
-                      "localoccupation",
-                    ],
-                    "type": "string",
-                  },
                   "preferredLabel": {
-                    "description": "The preferred label of the occupation.",
+                    "description": "The preferred label of the parent occupation.",
                     "maxLength": 256,
                     "pattern": "\\S",
                     "type": "string",
                   },
                 },
-                "required": [
-                  "id",
-                  "UUID",
-                  "preferredLabel",
-                  "occupationGroupCode",
-                  "code",
-                  "occupationType",
-                  "isLocalized",
-                  "model",
+                "type": [
+                  "object",
+                  "null",
                 ],
-                "type": "object",
               },
-              "type": "array",
+              "path": {
+                "description": "Resource path using the occupation's ID.",
+                "format": "uri",
+                "maxLength": 4096,
+                "pattern": "^https://.*",
+                "type": "string",
+              },
+              "preferredLabel": {
+                "description": "The preferred label of the occupation.",
+                "maxLength": 256,
+                "pattern": "\\S",
+                "type": "string",
+              },
+              "regulatedProfessionNote": {
+                "description": "Regulatory information for legally regulated professions.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+              "requiresSkills": {
+                "description": "Skills required for this occupation with relationship metadata.",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "UUID": {
+                      "description": "The UUID of the required skill.",
+                      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                      "type": "string",
+                    },
+                    "id": {
+                      "description": "The ID of the required skill.",
+                      "pattern": "^[0-9a-f]{24}$",
+                      "type": "string",
+                    },
+                    "isLocalized": {
+                      "description": "Indicates if the required skill is localized.",
+                      "type": "boolean",
+                    },
+                    "objectType": {
+                      "description": "The object type of the required skill.",
+                      "enum": [
+                        "skill",
+                      ],
+                      "type": "string",
+                    },
+                    "preferredLabel": {
+                      "description": "The preferred label of the required skill.",
+                      "maxLength": 256,
+                      "pattern": "\\S",
+                      "type": "string",
+                    },
+                    "relationType": {
+                      "description": "Used for ESCOOccupations only.",
+                      "enum": [
+                        "",
+                        "essential",
+                        "optional",
+                        null,
+                      ],
+                      "type": [
+                        "string",
+                        "null",
+                      ],
+                    },
+                    "signallingValue": {
+                      "description": "Used for LocalOccupations only.",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": [
+                        "number",
+                        "null",
+                      ],
+                    },
+                    "signallingValueLabel": {
+                      "description": "Used for LocalOccupations only.",
+                      "maxLength": 256,
+                      "pattern": "\\S",
+                      "type": [
+                        "string",
+                        "null",
+                      ],
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "UUID",
+                    "preferredLabel",
+                    "isLocalized",
+                    "objectType",
+                  ],
+                  "type": "object",
+                },
+                "minItems": 0,
+                "type": "array",
+              },
+              "scopeNote": {
+                "description": "Scope clarification for the occupation's application.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+              "tabiyaPath": {
+                "description": "Resource path using the occupation's UUID.",
+                "format": "uri",
+                "maxLength": 4096,
+                "pattern": "^https://.*",
+                "type": "string",
+              },
+              "updatedAt": {
+                "description": "Timestamp of last record modification.",
+                "format": "date-time",
+                "type": "string",
+              },
+            },
+            "required": [
+              "id",
+              "UUID",
+              "originUUID",
+              "UUIDHistory",
+              "path",
+              "tabiyaPath",
+              "code",
+              "occupationGroupCode",
+              "originUri",
+              "preferredLabel",
+              "altLabels",
+              "definition",
+              "description",
+              "regulatedProfessionNote",
+              "scopeNote",
+              "occupationType",
+              "modelId",
+              "isLocalized",
+              "parent",
+              "requiresSkills",
+              "children",
+              "createdAt",
+              "updatedAt",
+            ],
+            "type": "object",
+          },
+        },
+      },
+    },
+    "PUT": {
+      "Constants": {
+        "MAX_JSON_OVERHEAD": 10000,
+        "MAX_PUT_PAYLOAD_LENGTH": 566656,
+      },
+      "Enums": {
+        "OccupationToSkillRelationType": {
+          "ESSENTIAL": "essential",
+          "NONE": "",
+          "OPTIONAL": "optional",
+        },
+        "OccupationType": {
+          "ESCOOccupation": "escooccupation",
+          "LocalOccupation": "localoccupation",
+        },
+        "Relations": {
+          "Children": {
+            "ObjectTypes": {
+              "ESCOOccupation": "escooccupation",
+              "ISCOGroup": "iscogroup",
+              "LocalGroup": "localgroup",
+              "LocalOccupation": "localoccupation",
+            },
+          },
+          "Parent": {
+            "ObjectTypes": {
+              "ESCOOccupation": "escooccupation",
+              "ISCOGroup": "iscogroup",
+              "LocalGroup": "localgroup",
+              "LocalOccupation": "localoccupation",
+            },
+          },
+          "RequiredSkills": {
+            "ObjectTypes": {
+              "Skill": "skill",
             },
           },
         },
       },
-      "Patterns": {
-        "RegExp": {
-          "ESCO_LOCAL_OCCUPATION_CODE": /\\^\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\*\\(\\?:_\\\\d\\+\\)\\+\\$/,
-          "ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE": /\\^\\(\\?:\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\*\\(\\?:_\\\\d\\+\\)\\+\\|\\[a-zA-Z\\\\d\\]\\+\\(\\?:_\\\\d\\+\\)\\+\\)\\$/,
-          "ESCO_OCCUPATION_CODE": /\\^\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\+\\$/,
-          "ISCO_GROUP_CODE": /\\^\\\\d\\{1,4\\}\\$/,
-          "LOCAL_GROUP_CODE": /\\^\\(\\?:\\\\d\\{1,4\\}\\)\\?\\[a-zA-Z\\]\\+\\[a-zA-Z\\\\d\\]\\*\\$/,
-          "LOCAL_OCCUPATION_CODE": /\\(\\^\\[a-zA-Z\\\\d\\]\\+\\)\\(\\?:_\\\\d\\+\\)\\+\\$/,
+      "Errors": {
+        "Status400": {
+          "ErrorCodes": {
+            "INVALID_MODEL_ID": "INVALID_MODEL_ID",
+            "OCCUPATION_COULD_NOT_VALIDATE": "OCCUPATION_COULD_NOT_VALIDATE",
+            "UNABLE_TO_ALTER_RELEASED_MODEL": "UNABLE_TO_ALTER_RELEASED_MODEL",
+          },
         },
-        "Str": {
-          "ESCO_LOCAL_OCCUPATION_CODE": "^\\d{4}(?:\\.\\d+)*(?:_\\d+)+$",
-          "ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
-          "ESCO_OCCUPATION_CODE": "^\\d{4}(?:\\.\\d+)+$",
-          "ISCO_GROUP_CODE": "^\\d{1,4}$",
-          "LOCAL_GROUP_CODE": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
-          "LOCAL_OCCUPATION_CODE": "(^[a-zA-Z\\d]+)(?:_\\d+)+$",
+        "Status404": {
+          "ErrorCodes": {
+            "MODEL_NOT_FOUND": "MODEL_NOT_FOUND",
+            "OCCUPATION_NOT_FOUND": "OCCUPATION_NOT_FOUND",
+          },
+        },
+        "Status500": {
+          "ErrorCodes": {
+            "DB_FAILED_TO_UPDATE_OCCUPATION": "DB_FAILED_TO_UPDATE_OCCUPATION",
+          },
         },
       },
-      "Types": {},
+      "Schemas": {
+        "Request": {
+          "Payload": {
+            "$id": "/components/schemas/OccupationRequestSchemaPUT",
+            "additionalProperties": false,
+            "else": {
+              "properties": {
+                "code": {
+                  "maxLength": 100,
+                  "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                  "type": "string",
+                },
+                "occupationGroupCode": {
+                  "maxLength": 100,
+                  "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                  "type": "string",
+                },
+              },
+            },
+            "if": {
+              "properties": {
+                "occupationType": {
+                  "const": "escooccupation",
+                },
+              },
+            },
+            "properties": {
+              "UUIDHistory": {
+                "description": "The UUIDs history of the occupation.",
+                "items": {
+                  "maxLength": 50,
+                  "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                  "type": "string",
+                },
+                "maxItems": 10000,
+                "minItems": 0,
+                "type": "array",
+                "uniqueItems": true,
+              },
+              "altLabels": {
+                "description": "Alternative labels for the occupation.",
+                "items": {
+                  "maxLength": 256,
+                  "type": "string",
+                },
+                "maxItems": 100,
+                "minItems": 0,
+                "type": "array",
+                "uniqueItems": true,
+              },
+              "code": {
+                "description": "The code of the occupation.",
+                "maxLength": 256,
+                "type": "string",
+              },
+              "definition": {
+                "description": "The formal definition of the occupation.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+              "description": {
+                "description": "Additional descriptive information about the occupation.",
+                "maxLength": 6000,
+                "type": "string",
+              },
+              "isLocalized": {
+                "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
+                "type": "boolean",
+              },
+              "modelId": {
+                "description": "The identifier of the model containing this occupation.",
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string",
+              },
+              "occupationGroupCode": {
+                "description": "The code of the parent occupation group.",
+                "maxLength": 256,
+                "type": "string",
+              },
+              "occupationType": {
+                "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
+                "enum": [
+                  "escooccupation",
+                  "localoccupation",
+                ],
+                "type": "string",
+              },
+              "originUri": {
+                "description": "The origin URI of the occupation.",
+                "format": "uri",
+                "maxLength": 4096,
+                "pattern": "\\S",
+                "type": "string",
+              },
+              "preferredLabel": {
+                "description": "The preferred label of the occupation.",
+                "maxLength": 256,
+                "pattern": "\\S",
+                "type": "string",
+              },
+              "regulatedProfessionNote": {
+                "description": "Regulatory information for legally regulated professions.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+              "scopeNote": {
+                "description": "Scope clarification for the occupation's application.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "occupationGroupCode",
+              "preferredLabel",
+              "originUri",
+              "UUIDHistory",
+              "altLabels",
+              "definition",
+              "description",
+              "regulatedProfessionNote",
+              "scopeNote",
+              "modelId",
+              "occupationType",
+              "isLocalized",
+            ],
+            "then": {
+              "properties": {
+                "code": {
+                  "maxLength": 100,
+                  "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                  "type": "string",
+                },
+                "occupationGroupCode": {
+                  "maxLength": 100,
+                  "pattern": "^\\d{1,4}$",
+                  "type": "string",
+                },
+              },
+            },
+            "type": "object",
+          },
+        },
+        "Response": {
+          "Payload": {
+            "$id": "/components/schemas/OccupationResponseSchemaPUT",
+            "additionalProperties": false,
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "occupationType": {
+                      "const": "escooccupation",
+                    },
+                  },
+                },
+                "then": {
+                  "properties": {
+                    "code": {
+                      "maxLength": 256,
+                      "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                      "type": "string",
+                    },
+                    "occupationGroupCode": {
+                      "maxLength": 256,
+                      "pattern": "^\\d{1,4}$",
+                      "type": "string",
+                    },
+                  },
+                },
+              },
+              {
+                "if": {
+                  "properties": {
+                    "occupationType": {
+                      "const": "localoccupation",
+                    },
+                  },
+                },
+                "then": {
+                  "properties": {
+                    "code": {
+                      "maxLength": 256,
+                      "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                      "type": "string",
+                    },
+                    "occupationGroupCode": {
+                      "maxLength": 256,
+                      "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                      "type": "string",
+                    },
+                  },
+                },
+              },
+              {
+                "if": {
+                  "properties": {
+                    "occupationType": {
+                      "const": "escooccupation",
+                    },
+                  },
+                },
+                "then": {
+                  "properties": {
+                    "requiresSkills": {
+                      "items": {
+                        "properties": {
+                          "relationType": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "relationType",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                },
+              },
+              {
+                "if": {
+                  "properties": {
+                    "occupationType": {
+                      "const": "localoccupation",
+                    },
+                  },
+                },
+                "then": {
+                  "properties": {
+                    "requiresSkills": {
+                      "items": {
+                        "properties": {
+                          "signallingValue": {
+                            "type": "number",
+                          },
+                          "signallingValueLabel": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "signallingValue",
+                          "signallingValueLabel",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                },
+              },
+            ],
+            "properties": {
+              "UUID": {
+                "description": "The UUID of the occupation for cross-system identification.",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                "type": "string",
+              },
+              "UUIDHistory": {
+                "description": "The UUIDs history of the occupation.",
+                "items": {
+                  "maxLength": 50,
+                  "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                  "type": "string",
+                },
+                "maxItems": 10000,
+                "minItems": 0,
+                "type": "array",
+                "uniqueItems": true,
+              },
+              "altLabels": {
+                "description": "Alternative labels for the occupation.",
+                "items": {
+                  "maxLength": 256,
+                  "type": "string",
+                },
+                "maxItems": 100,
+                "minItems": 0,
+                "type": "array",
+                "uniqueItems": true,
+              },
+              "children": {
+                "description": "The children of this occupation.",
+                "items": {
+                  "additionalProperties": false,
+                  "allOf": [
+                    {
+                      "if": {
+                        "properties": {
+                          "objectType": {
+                            "const": "escooccupation",
+                          },
+                        },
+                      },
+                      "then": {
+                        "properties": {
+                          "code": {
+                            "maxLength": 256,
+                            "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                            "type": "string",
+                          },
+                          "occupationGroupCode": {
+                            "maxLength": 256,
+                            "pattern": "^\\d{1,4}$",
+                            "type": "string",
+                          },
+                        },
+                      },
+                    },
+                    {
+                      "if": {
+                        "properties": {
+                          "objectType": {
+                            "const": "localoccupation",
+                          },
+                        },
+                      },
+                      "then": {
+                        "properties": {
+                          "code": {
+                            "maxLength": 256,
+                            "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                            "type": "string",
+                          },
+                          "occupationGroupCode": {
+                            "maxLength": 256,
+                            "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                            "type": "string",
+                          },
+                        },
+                      },
+                    },
+                  ],
+                  "properties": {
+                    "UUID": {
+                      "description": "The UUID of the child occupation.",
+                      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                      "type": "string",
+                    },
+                    "code": {
+                      "description": "The code of the child occupation.",
+                      "maxLength": 256,
+                      "type": "string",
+                    },
+                    "id": {
+                      "description": "The id of the child occupation.",
+                      "pattern": "^[0-9a-f]{24}$",
+                      "type": "string",
+                    },
+                    "objectType": {
+                      "description": "The type of the occupation child (EscoOccupation or LocalOccupation).",
+                      "enum": [
+                        "escooccupation",
+                        "localoccupation",
+                      ],
+                      "type": "string",
+                    },
+                    "occupationGroupCode": {
+                      "description": "The code of the child occupation group.",
+                      "maxLength": 256,
+                      "type": "string",
+                    },
+                    "preferredLabel": {
+                      "description": "The preferred label of the child occupation.",
+                      "maxLength": 256,
+                      "pattern": "\\S",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+                "minItems": 0,
+                "type": "array",
+              },
+              "code": {
+                "description": "The code of the occupation.",
+                "maxLength": 256,
+                "type": "string",
+              },
+              "createdAt": {
+                "description": "Timestamp of record creation.",
+                "format": "date-time",
+                "type": "string",
+              },
+              "definition": {
+                "description": "The formal definition of the occupation.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+              "description": {
+                "description": "Additional descriptive information about the occupation.",
+                "maxLength": 6000,
+                "type": "string",
+              },
+              "id": {
+                "description": "The unique identifier of the occupation.",
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string",
+              },
+              "isLocalized": {
+                "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
+                "type": "boolean",
+              },
+              "modelId": {
+                "description": "The identifier of the model containing this occupation.",
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string",
+              },
+              "occupationGroupCode": {
+                "description": "The code of the parent occupation group.",
+                "maxLength": 256,
+                "type": "string",
+              },
+              "occupationType": {
+                "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
+                "enum": [
+                  "escooccupation",
+                  "localoccupation",
+                ],
+                "type": "string",
+              },
+              "originUUID": {
+                "description": "The original UUID of the occupation, i.e., the first UUID in UUIDHistory",
+                "maxLength": 50,
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                "type": "string",
+              },
+              "originUri": {
+                "description": "The origin URI of the occupation.",
+                "format": "uri",
+                "maxLength": 4096,
+                "pattern": "\\S",
+                "type": "string",
+              },
+              "parent": {
+                "additionalProperties": false,
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "iscogroup",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{1,4}$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{1,4}$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "localgroup",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "escooccupation",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{4}(?:\\.\\d+)+$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^\\d{1,4}$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "objectType": {
+                          "const": "localoccupation",
+                        },
+                      },
+                    },
+                    "then": {
+                      "properties": {
+                        "code": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                          "type": "string",
+                        },
+                        "occupationGroupCode": {
+                          "maxLength": 256,
+                          "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                          "type": "string",
+                        },
+                      },
+                    },
+                  },
+                ],
+                "description": "The parent occupation of this occupation.",
+                "properties": {
+                  "UUID": {
+                    "description": "The UUID of the occupation. It can be used to identify the parent occupation.",
+                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    "type": "string",
+                  },
+                  "code": {
+                    "description": "The code of the parent occupation.",
+                    "maxLength": 256,
+                    "type": "string",
+                  },
+                  "id": {
+                    "description": "The id of the parent occupation.",
+                    "pattern": "^[0-9a-f]{24}$",
+                    "type": "string",
+                  },
+                  "objectType": {
+                    "description": "The type of the occupation parent (LocalOccupation, ESCOOccupation, ISCOGroup or LocalGroup).",
+                    "enum": [
+                      "iscogroup",
+                      "localgroup",
+                      "escooccupation",
+                      "localoccupation",
+                    ],
+                    "type": "string",
+                  },
+                  "occupationGroupCode": {
+                    "description": "The code of the parent occupation group.",
+                    "maxLength": 256,
+                    "type": "string",
+                  },
+                  "preferredLabel": {
+                    "description": "The preferred label of the parent occupation.",
+                    "maxLength": 256,
+                    "pattern": "\\S",
+                    "type": "string",
+                  },
+                },
+                "type": [
+                  "object",
+                  "null",
+                ],
+              },
+              "path": {
+                "description": "Resource path using the occupation's ID.",
+                "format": "uri",
+                "maxLength": 4096,
+                "pattern": "^https://.*",
+                "type": "string",
+              },
+              "preferredLabel": {
+                "description": "The preferred label of the occupation.",
+                "maxLength": 256,
+                "pattern": "\\S",
+                "type": "string",
+              },
+              "regulatedProfessionNote": {
+                "description": "Regulatory information for legally regulated professions.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+              "requiresSkills": {
+                "description": "Skills required for this occupation with relationship metadata.",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "UUID": {
+                      "description": "The UUID of the required skill.",
+                      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                      "type": "string",
+                    },
+                    "id": {
+                      "description": "The ID of the required skill.",
+                      "pattern": "^[0-9a-f]{24}$",
+                      "type": "string",
+                    },
+                    "isLocalized": {
+                      "description": "Indicates if the required skill is localized.",
+                      "type": "boolean",
+                    },
+                    "objectType": {
+                      "description": "The object type of the required skill.",
+                      "enum": [
+                        "skill",
+                      ],
+                      "type": "string",
+                    },
+                    "preferredLabel": {
+                      "description": "The preferred label of the required skill.",
+                      "maxLength": 256,
+                      "pattern": "\\S",
+                      "type": "string",
+                    },
+                    "relationType": {
+                      "description": "Used for ESCOOccupations only.",
+                      "enum": [
+                        "",
+                        "essential",
+                        "optional",
+                        null,
+                      ],
+                      "type": [
+                        "string",
+                        "null",
+                      ],
+                    },
+                    "signallingValue": {
+                      "description": "Used for LocalOccupations only.",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": [
+                        "number",
+                        "null",
+                      ],
+                    },
+                    "signallingValueLabel": {
+                      "description": "Used for LocalOccupations only.",
+                      "maxLength": 256,
+                      "pattern": "\\S",
+                      "type": [
+                        "string",
+                        "null",
+                      ],
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "UUID",
+                    "preferredLabel",
+                    "isLocalized",
+                    "objectType",
+                  ],
+                  "type": "object",
+                },
+                "minItems": 0,
+                "type": "array",
+              },
+              "scopeNote": {
+                "description": "Scope clarification for the occupation's application.",
+                "maxLength": 4000,
+                "type": "string",
+              },
+              "tabiyaPath": {
+                "description": "Resource path using the occupation's UUID.",
+                "format": "uri",
+                "maxLength": 4096,
+                "pattern": "^https://.*",
+                "type": "string",
+              },
+              "updatedAt": {
+                "description": "Timestamp of last record modification.",
+                "format": "date-time",
+                "type": "string",
+              },
+            },
+            "required": [
+              "id",
+              "UUID",
+              "originUUID",
+              "UUIDHistory",
+              "path",
+              "tabiyaPath",
+              "code",
+              "occupationGroupCode",
+              "originUri",
+              "preferredLabel",
+              "altLabels",
+              "definition",
+              "description",
+              "regulatedProfessionNote",
+              "scopeNote",
+              "occupationType",
+              "modelId",
+              "isLocalized",
+              "parent",
+              "requiresSkills",
+              "children",
+              "createdAt",
+              "updatedAt",
+            ],
+            "type": "object",
+          },
+        },
+      },
     },
     "Parent": {
       "Constants": {
         "ALT_LABELS_MAX_ITEMS": 100,
         "ALT_LABEL_MAX_LENGTH": 256,
         "CODE_MAX_LENGTH": 256,
+        "CODE_PATTERN_MAX_LENGTH": 100,
         "DEFAULT_LIMIT": 10,
         "DEFINITION_MAX_LENGTH": 4000,
         "DESCRIPTION_MAX_LENGTH": 6000,
@@ -3733,6 +5111,7 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
         "ALT_LABELS_MAX_ITEMS": 100,
         "ALT_LABEL_MAX_LENGTH": 256,
         "CODE_MAX_LENGTH": 256,
+        "CODE_PATTERN_MAX_LENGTH": 100,
         "DEFAULT_LIMIT": 10,
         "DEFINITION_MAX_LENGTH": 4000,
         "DESCRIPTION_MAX_LENGTH": 6000,
@@ -5853,62 +7232,6 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
       "ISCO_GROUP_CODE": "^\\d{1,4}$",
       "LOCAL_GROUP_CODE": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
       "LOCAL_OCCUPATION_CODE": "(^[a-zA-Z\\d]+)(?:_\\d+)+$",
-    },
-  },
-  "Schemas": {
-    "Reference": {
-      "$id": "/components/schemas/OccupationReferenceSchema",
-      "additionalProperties": false,
-      "properties": {
-        "UUID": {
-          "description": "The UUID of the occupation.",
-          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-          "type": "string",
-        },
-        "code": {
-          "description": "The code of the occupation.",
-          "maxLength": 256,
-          "type": "string",
-        },
-        "id": {
-          "description": "The id of the occupation.",
-          "pattern": "^[0-9a-f]{24}$",
-          "type": "string",
-        },
-        "isLocalized": {
-          "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
-          "type": "boolean",
-        },
-        "occupationGroupCode": {
-          "description": "The code of the parent occupation group.",
-          "maxLength": 256,
-          "type": "string",
-        },
-        "occupationType": {
-          "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
-          "enum": [
-            "escooccupation",
-            "localoccupation",
-          ],
-          "type": "string",
-        },
-        "preferredLabel": {
-          "description": "The preferred label of the occupation.",
-          "maxLength": 256,
-          "pattern": "\\S",
-          "type": "string",
-        },
-      },
-      "required": [
-        "id",
-        "UUID",
-        "preferredLabel",
-        "occupationGroupCode",
-        "code",
-        "occupationType",
-        "isLocalized",
-      ],
-      "type": "object",
     },
   },
   "Types": {},

--- a/api-specifications/src/esco/occupation/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/esco/occupation/__snapshots__/index.test.ts.snap
@@ -1580,6 +1580,170 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
         },
       },
     },
+    "History": {
+      "Constants": {
+        "ALT_LABELS_MAX_ITEMS": 100,
+        "ALT_LABEL_MAX_LENGTH": 256,
+        "CODE_MAX_LENGTH": 256,
+        "CODE_PATTERN_MAX_LENGTH": 100,
+        "DEFAULT_LIMIT": 10,
+        "DEFINITION_MAX_LENGTH": 4000,
+        "DESCRIPTION_MAX_LENGTH": 6000,
+        "MAX_CURSOR_LENGTH": 1024,
+        "MAX_LIMIT": 100,
+        "MAX_PAYLOAD_LENGTH": 1000,
+        "OCCUPATION_GROUP_CODE_MAX_LENGTH": 256,
+        "ORIGIN_URI_MAX_LENGTH": 4096,
+        "PATH_URI_MAX_LENGTH": 4096,
+        "PREFERRED_LABEL_MAX_LENGTH": 256,
+        "REGULATED_PROFESSION_NOTE_MAX_LENGTH": 4000,
+        "SCOPE_NOTE_MAX_LENGTH": 4000,
+        "SIGNALLING_VALUE_LABEL_MAX_LENGTH": 256,
+        "SIGNALLING_VALUE_MAX": 100,
+        "SIGNALLING_VALUE_MIN": 0,
+        "TABIYA_PATH_URI_MAX_LENGTH": 4096,
+        "UUID_HISTORY_MAX_ITEMS": 10000,
+        "UUID_HISTORY_MAX_LENGTH": 50,
+      },
+      "Enums": {
+        "OccupationToSkillRelationType": {
+          "ESSENTIAL": "essential",
+          "NONE": "",
+          "OPTIONAL": "optional",
+        },
+        "OccupationType": {
+          "ESCOOccupation": "escooccupation",
+          "LocalOccupation": "localoccupation",
+        },
+        "Relations": {
+          "Children": {
+            "ObjectTypes": {
+              "ESCOOccupation": "escooccupation",
+              "ISCOGroup": "iscogroup",
+              "LocalGroup": "localgroup",
+              "LocalOccupation": "localoccupation",
+            },
+          },
+          "Parent": {
+            "ObjectTypes": {
+              "ESCOOccupation": "escooccupation",
+              "ISCOGroup": "iscogroup",
+              "LocalGroup": "localgroup",
+              "LocalOccupation": "localoccupation",
+            },
+          },
+          "RequiredSkills": {
+            "ObjectTypes": {
+              "Skill": "skill",
+            },
+          },
+        },
+      },
+      "GET": {
+        "Errors": {
+          "Status400": {
+            "ErrorCodes": {
+              "INVALID_OCCUPATION_ID": "INVALID_OCCUPATION_ID",
+            },
+          },
+          "Status404": {
+            "ErrorCodes": {
+              "MODEL_NOT_FOUND": "MODEL_NOT_FOUND",
+              "OCCUPATION_NOT_FOUND": "OCCUPATION_NOT_FOUND",
+            },
+          },
+          "Status500": {
+            "ErrorCodes": {
+              "DB_FAILED_TO_RETRIEVE_OCCUPATION_HISTORY": "DB_FAILED_TO_RETRIEVE_OCCUPATION_HISTORY",
+            },
+          },
+        },
+        "Schemas": {
+          "Response": {
+            "Payload": {
+              "$id": "/components/schemas/OccupationResponseSchemaGETHistory",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "UUID": {
+                    "description": "The UUID of the occupation.",
+                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    "type": "string",
+                  },
+                  "code": {
+                    "description": "The code of the occupation.",
+                    "maxLength": 256,
+                    "type": "string",
+                  },
+                  "id": {
+                    "description": "The id of the occupation.",
+                    "pattern": "^[0-9a-f]{24}$",
+                    "type": "string",
+                  },
+                  "isLocalized": {
+                    "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
+                    "type": "boolean",
+                  },
+                  "model": {
+                    "$ref": "/components/schemas/ModelInfoReferenceSchema",
+                  },
+                  "occupationGroupCode": {
+                    "description": "The code of the parent occupation group.",
+                    "maxLength": 256,
+                    "type": "string",
+                  },
+                  "occupationType": {
+                    "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
+                    "enum": [
+                      "escooccupation",
+                      "localoccupation",
+                    ],
+                    "type": "string",
+                  },
+                  "preferredLabel": {
+                    "description": "The preferred label of the occupation.",
+                    "maxLength": 256,
+                    "pattern": "\\S",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "id",
+                  "UUID",
+                  "preferredLabel",
+                  "occupationGroupCode",
+                  "code",
+                  "occupationType",
+                  "isLocalized",
+                  "model",
+                ],
+                "type": "object",
+              },
+              "type": "array",
+            },
+          },
+        },
+      },
+      "Patterns": {
+        "RegExp": {
+          "ESCO_LOCAL_OCCUPATION_CODE": /\\^\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\*\\(\\?:_\\\\d\\+\\)\\+\\$/,
+          "ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE": /\\^\\(\\?:\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\*\\(\\?:_\\\\d\\+\\)\\+\\|\\[a-zA-Z\\\\d\\]\\+\\(\\?:_\\\\d\\+\\)\\+\\)\\$/,
+          "ESCO_OCCUPATION_CODE": /\\^\\\\d\\{4\\}\\(\\?:\\\\\\.\\\\d\\+\\)\\+\\$/,
+          "ISCO_GROUP_CODE": /\\^\\\\d\\{1,4\\}\\$/,
+          "LOCAL_GROUP_CODE": /\\^\\(\\?:\\\\d\\{1,4\\}\\)\\?\\[a-zA-Z\\]\\+\\[a-zA-Z\\\\d\\]\\*\\$/,
+          "LOCAL_OCCUPATION_CODE": /\\(\\^\\[a-zA-Z\\\\d\\]\\+\\)\\(\\?:_\\\\d\\+\\)\\+\\$/,
+        },
+        "Str": {
+          "ESCO_LOCAL_OCCUPATION_CODE": "^\\d{4}(?:\\.\\d+)*(?:_\\d+)+$",
+          "ESCO_LOCAL_OR_LOCAL_OCCUPATION_CODE": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+          "ESCO_OCCUPATION_CODE": "^\\d{4}(?:\\.\\d+)+$",
+          "ISCO_GROUP_CODE": "^\\d{1,4}$",
+          "LOCAL_GROUP_CODE": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+          "LOCAL_OCCUPATION_CODE": "(^[a-zA-Z\\d]+)(?:_\\d+)+$",
+        },
+      },
+      "Types": {},
+    },
     "PATCH": {
       "Constants": {
         "MAX_JSON_OVERHEAD": 10000,
@@ -7247,6 +7411,62 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
       "ISCO_GROUP_CODE": "^\\d{1,4}$",
       "LOCAL_GROUP_CODE": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
       "LOCAL_OCCUPATION_CODE": "(^[a-zA-Z\\d]+)(?:_\\d+)+$",
+    },
+  },
+  "Schemas": {
+    "Reference": {
+      "$id": "/components/schemas/OccupationReferenceSchema",
+      "additionalProperties": false,
+      "properties": {
+        "UUID": {
+          "description": "The UUID of the occupation.",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+          "type": "string",
+        },
+        "code": {
+          "description": "The code of the occupation.",
+          "maxLength": 256,
+          "type": "string",
+        },
+        "id": {
+          "description": "The id of the occupation.",
+          "pattern": "^[0-9a-f]{24}$",
+          "type": "string",
+        },
+        "isLocalized": {
+          "description": "Indicates if the occupation has localized variants. Must be false for LocalOccupation.",
+          "type": "boolean",
+        },
+        "occupationGroupCode": {
+          "description": "The code of the parent occupation group.",
+          "maxLength": 256,
+          "type": "string",
+        },
+        "occupationType": {
+          "description": "The occupation classification type (e.g., ESCOOccupation or LocalOccupation).",
+          "enum": [
+            "escooccupation",
+            "localoccupation",
+          ],
+          "type": "string",
+        },
+        "preferredLabel": {
+          "description": "The preferred label of the occupation.",
+          "maxLength": 256,
+          "pattern": "\\S",
+          "type": "string",
+        },
+      },
+      "required": [
+        "id",
+        "UUID",
+        "preferredLabel",
+        "occupationGroupCode",
+        "code",
+        "occupationType",
+        "isLocalized",
+      ],
+      "type": "object",
     },
   },
   "Types": {},

--- a/api-specifications/src/esco/occupation/__snapshots__/index.test.ts.snap
+++ b/api-specifications/src/esco/occupation/__snapshots__/index.test.ts.snap
@@ -1645,16 +1645,28 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
             "$id": "/components/schemas/OccupationRequestSchemaPATCH",
             "additionalProperties": false,
             "else": {
-              "properties": {
-                "code": {
-                  "maxLength": 100,
-                  "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
-                  "type": "string",
+              "if": {
+                "properties": {
+                  "occupationType": {
+                    "const": "localoccupation",
+                  },
                 },
-                "occupationGroupCode": {
-                  "maxLength": 100,
-                  "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
-                  "type": "string",
+                "required": [
+                  "occupationType",
+                ],
+              },
+              "then": {
+                "properties": {
+                  "code": {
+                    "maxLength": 100,
+                    "pattern": "^(?:\\d{4}(?:\\.\\d+)*(?:_\\d+)+|[a-zA-Z\\d]+(?:_\\d+)+)$",
+                    "type": "string",
+                  },
+                  "occupationGroupCode": {
+                    "maxLength": 100,
+                    "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
+                    "type": "string",
+                  },
                 },
               },
             },
@@ -1664,6 +1676,9 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
                   "const": "escooccupation",
                 },
               },
+              "required": [
+                "occupationType",
+              ],
             },
             "properties": {
               "UUIDHistory": {
@@ -2414,7 +2429,7 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
                 },
                 "occupationGroupCode": {
                   "maxLength": 100,
-                  "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                  "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
                   "type": "string",
                 },
               },
@@ -6513,7 +6528,7 @@ exports[`Test the Occupation module The export module matches the snapshot 1`] =
               },
               "occupationGroupCode": {
                 "maxLength": 100,
-                "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$",
+                "pattern": "^(?:\\d{1,4})?[a-zA-Z]+[a-zA-Z\\d]*$|^\\d{1,4}$",
                 "type": "string",
               },
             },

--- a/api-specifications/src/esco/occupation/_shared/constants.ts
+++ b/api-specifications/src/esco/occupation/_shared/constants.ts
@@ -1,6 +1,7 @@
 namespace OccupationConstants {
   // Text field max lengths
   export const DESCRIPTION_MAX_LENGTH = 6000;
+  export const CODE_PATTERN_MAX_LENGTH = 100;
   export const DEFINITION_MAX_LENGTH = 4000;
   export const PREFERRED_LABEL_MAX_LENGTH = 256;
   export const ALT_LABEL_MAX_LENGTH = 256;

--- a/api-specifications/src/esco/occupation/_shared/types.ts
+++ b/api-specifications/src/esco/occupation/_shared/types.ts
@@ -174,6 +174,24 @@ namespace OccupationTypes {
     }
   }
 
+  export namespace Detail.PUT {
+    export namespace Request {
+      export type Payload = IOccupationRequest;
+    }
+    export namespace Response {
+      export type Payload = IOccupationResponse;
+    }
+  }
+
+  export namespace Detail.PATCH {
+    export namespace Request {
+      export type Payload = Partial<IOccupationRequest>;
+    }
+    export namespace Response {
+      export type Payload = IOccupationResponse;
+    }
+  }
+
   export namespace Detail.parent.GET {
     export namespace Response {
       export type Payload = IOccupationResponse | OccupationGroupTypes.Response.IOccupationGroup | null;

--- a/backend/openapi/generateOpenApiDoc.ts
+++ b/backend/openapi/generateOpenApiDoc.ts
@@ -23,15 +23,6 @@ ModelInfo.Schemas.POST.Request.Payload.properties.locale.$ref =
   "#" + ModelInfo.Schemas.POST.Request.Payload.properties.locale.$ref;
 ModelInfo.Schemas.GET.Response.Payload.items.properties.locale.$ref =
   "#" + ModelInfo.Schemas.GET.Response.Payload.items.properties.locale.$ref;
-// Each history item embeds a stripped-down `model` (a ModelInfoReference) via $ref that must be prefixed with "#".
-Occupation.Occupation.History.GET.Schemas.Response.Payload.items.properties.model.$ref =
-  "#" + Occupation.Occupation.History.GET.Schemas.Response.Payload.items.properties.model.$ref;
-OccupationGroup.OccupationGroup.History.GET.Schemas.Response.Payload.items.properties.model.$ref =
-  "#" + OccupationGroup.OccupationGroup.History.GET.Schemas.Response.Payload.items.properties.model.$ref;
-Skill.Skill.History.GET.Schemas.Response.Payload.items.properties.model.$ref =
-  "#" + Skill.Skill.History.GET.Schemas.Response.Payload.items.properties.model.$ref;
-SkillGroup.SkillGroup.History.GET.Schemas.Response.Payload.items.properties.model.$ref =
-  "#" + SkillGroup.SkillGroup.History.GET.Schemas.Response.Payload.items.properties.model.$ref;
 
 /**
  * Remove the $id from the schemas as Swagger does not like them.
@@ -40,11 +31,6 @@ SkillGroup.SkillGroup.History.GET.Schemas.Response.Payload.items.properties.mode
 delete ModelInfo.Schemas.POST.Response.Payload.$id;
 delete ModelInfo.Schemas.POST.Request.Payload.$id;
 delete ModelInfo.Schemas.GET.Response.Payload.$id;
-delete ModelInfo.Schemas.Reference.$id;
-delete Occupation.Schemas.Reference.$id;
-delete OccupationGroup.Schemas.Reference.$id;
-delete Skill.Schemas.Reference.$id;
-delete SkillGroup.Schemas.Reference.$id;
 delete Locale.Schemas.Payload.$id;
 delete Presigned.Schemas.GET.Response.Payload.$id;
 delete Import.Schemas.POST.Request.Payload.$id;
@@ -62,10 +48,8 @@ delete OccupationGroup.GET.Schemas.Request.Query.Payload.$id;
 delete OccupationGroup.OccupationGroup.Schemas.Request.Param.Payload.$id;
 delete OccupationGroup.OccupationGroup.GET.Schemas.Response.Payload.$id;
 delete OccupationGroup.OccupationGroup.GET.Schemas.Response.Payload.$id;
-delete OccupationGroup.OccupationGroup.Parent.POST.Schemas.Request.Payload.$id;
 delete OccupationGroup.OccupationGroup.Children.GET.Schemas.Response.Child.Payload.$id;
 delete OccupationGroup.OccupationGroup.Children.GET.Schemas.Response.Children.Payload.$id;
-delete OccupationGroup.OccupationGroup.History.GET.Schemas.Response.Payload.$id;
 delete Occupation.POST.Schemas.Request.Payload.$id;
 delete Occupation.POST.Schemas.Response.Payload.$id;
 delete Occupation.GET.Schemas.Response.Payload.$id;
@@ -79,7 +63,10 @@ delete Occupation.Occupation.Children.GET.Schemas.Request.Query.Payload.$id;
 delete Occupation.Occupation.Skills.GET.Schemas.Response.Payload.$id;
 delete Occupation.Occupation.Skills.POST.Schemas.Request.Payload.$id;
 delete Occupation.Occupation.Skills.GET.Schemas.Request.Query.Payload.$id;
-delete Occupation.Occupation.History.GET.Schemas.Response.Payload.$id;
+delete Occupation.Occupation.PUT.Schemas.Request.Payload.$id;
+delete Occupation.Occupation.PUT.Schemas.Response.Payload.$id;
+delete Occupation.Occupation.PATCH.Schemas.Request.Payload.$id;
+delete Occupation.Occupation.PATCH.Schemas.Response.Payload.$id;
 delete SkillGroup.POST.Schemas.Request.Param.Payload.$id;
 delete SkillGroup.POST.Schemas.Request.Payload.$id;
 delete SkillGroup.POST.Schemas.Response.Payload.$id;
@@ -96,7 +83,6 @@ delete SkillGroup.SkillGroup.Parent.POST.Schemas.Response.Payload.$id;
 delete SkillGroup.SkillGroup.Children.GET.Schemas.Request.Query.Payload.$id;
 delete SkillGroup.SkillGroup.Children.GET.Schemas.Response.Child.Payload.$id;
 delete SkillGroup.SkillGroup.Children.GET.Schemas.Response.Children.Payload.$id;
-delete SkillGroup.SkillGroup.History.GET.Schemas.Response.Payload.$id;
 delete Skill.POST.Schemas.Request.Payload.$id;
 delete Skill.POST.Schemas.Request.Param.Payload.$id;
 delete Skill.POST.Schemas.Response.Payload.$id;
@@ -119,7 +105,6 @@ delete Skill.Skill.RelatedSkills.GET.Schemas.Response.Payload.$id;
 delete Skill.Skill.RelatedSkills.GET.Schemas.Request.Query.Payload.$id;
 delete Skill.Skill.RelatedSkills.POST.Schemas.Request.Payload.$id;
 delete Skill.Skill.RelatedSkills.POST.Schemas.Response.Payload.$id;
-delete Skill.Skill.History.GET.Schemas.Response.Payload.$id;
 //--------------------------------------------------------------------------------------------------
 // Generate the openapi specification and store it in the build folder.
 //--------------------------------------------------------------------------------------------------
@@ -308,6 +293,31 @@ function getOpenAPISpecification(
               ...Object.values(Occupation.Occupation.Skills.GET.Errors.Status404.ErrorCodes),
             ]) as unknown as string[]),
           ]),
+          // PUT/PATCH Occupation-specific error schemas
+          PUTOccupation400ErrorSchema: APIError.Schemas.getPayload(
+            "PUT",
+            "Occupation",
+            400,
+            Object.values(Occupation.Occupation.PUT.Errors.Status400.ErrorCodes)
+          ),
+          PUTOccupation404ErrorSchema: APIError.Schemas.getPayload(
+            "PUT",
+            "Occupation",
+            404,
+            Object.values(Occupation.Occupation.PUT.Errors.Status404.ErrorCodes)
+          ),
+          PATCHOccupation400ErrorSchema: APIError.Schemas.getPayload(
+            "PATCH",
+            "Occupation",
+            400,
+            Object.values(Occupation.Occupation.PATCH.Errors.Status400.ErrorCodes)
+          ),
+          PATCHOccupation404ErrorSchema: APIError.Schemas.getPayload(
+            "PATCH",
+            "Occupation",
+            404,
+            Object.values(Occupation.Occupation.PATCH.Errors.Status404.ErrorCodes)
+          ),
           GETSkillGroup400ErrorSchema: APIError.Schemas.getPayload("GET", "SkillGroup", 400, [
             ...(new Set([
               ...Object.values(SkillGroup.GET.Enums.Response.Status400.ErrorCodes),
@@ -414,11 +424,6 @@ function getOpenAPISpecification(
           ModelInfoResponseSchemaPOST: ModelInfo.Schemas.POST.Response.Payload,
           ModelInfoRequestSchemaPOST: ModelInfo.Schemas.POST.Request.Payload,
           ModelInfoResponseSchemaGET: ModelInfo.Schemas.GET.Response.Payload,
-          ModelInfoReferenceSchema: ModelInfo.Schemas.Reference,
-          OccupationReferenceSchema: Occupation.Schemas.Reference,
-          OccupationGroupReferenceSchema: OccupationGroup.Schemas.Reference,
-          SkillReferenceSchema: Skill.Schemas.Reference,
-          SkillGroupReferenceSchema: SkillGroup.Schemas.Reference,
           LocaleSchema: Locale.Schemas.Payload,
           ImportSchema: Import.Schemas.POST.Request.Payload,
           ExportSchema: Export.Schemas.POST.Request.Payload,
@@ -429,12 +434,10 @@ function getOpenAPISpecification(
           OccupationGroupParentResponseSchemaGET: OccupationGroup.OccupationGroup.Parent.GET.Schemas.Response.Payload,
           OccupationGroupChildrenResponseSchemaGET:
             OccupationGroup.OccupationGroup.Children.GET.Schemas.Response.Children.Payload,
-          OccupationGroupResponseSchemaGETHistory: OccupationGroup.OccupationGroup.History.GET.Schemas.Response.Payload,
           OccupationGroupRequestParamSchemaGET: OccupationGroup.GET.Schemas.Request.Param.Payload,
           OccupationGroupRequestQueryParamSchemaGET: OccupationGroup.GET.Schemas.Request.Query.Payload,
           OccupationGroupResponseSchemaGET: OccupationGroup.GET.Schemas.Response.Payload,
           OccupationGroupRequestByIdParamSchemaGET: OccupationGroup.OccupationGroup.Schemas.Request.Param.Payload,
-          OccupationGroupParentRequestSchemaPOST: OccupationGroup.OccupationGroup.Parent.POST.Schemas.Request.Payload,
           OccupationRequestSchemaPOST: Occupation.POST.Schemas.Request.Payload,
           OccupationResponseSchemaPOST: Occupation.POST.Schemas.Response.Payload,
           OccupationRequestParamSchemaGET: Occupation.GET.Schemas.Request.Param.Payload,
@@ -450,6 +453,10 @@ function getOpenAPISpecification(
           OccupationSkillsRequestSchemaPOST: Occupation.Occupation.Skills.POST.Schemas.Request.Payload,
           OccupationSkillsRequestQueryParamSchemaGET: Occupation.Occupation.Skills.GET.Schemas.Request.Query.Payload,
           OccupationResponseSchemaGETHistory: Occupation.Occupation.History.GET.Schemas.Response.Payload,
+          OccupationRequestSchemaPUT: Occupation.Occupation.PUT.Schemas.Request.Payload,
+          OccupationResponseSchemaPUT: Occupation.Occupation.PUT.Schemas.Response.Payload,
+          OccupationRequestSchemaPATCH: Occupation.Occupation.PATCH.Schemas.Request.Payload,
+          OccupationResponseSchemaPATCH: Occupation.Occupation.PATCH.Schemas.Response.Payload,
           SkillGroupRequestSchemaPOST: SkillGroup.POST.Schemas.Request.Payload,
           SkillGroupResponseSchemaPOST: SkillGroup.POST.Schemas.Response.Payload,
           SkillGroupParentRequestSchemaPOST: SkillGroup.SkillGroup.Parent.POST.Schemas.Request.Payload,
@@ -458,7 +465,6 @@ function getOpenAPISpecification(
           SkillGroupParentsResponseSchemaGET: SkillGroup.SkillGroup.Parent.GET.Schemas.Response.Parents.Payload,
           SkillGroupParentsRequestQueryParamSchemaGET: SkillGroup.SkillGroup.Parent.GET.Schemas.Request.Query.Payload,
           SkillGroupChildrenResponseSchemaGET: SkillGroup.SkillGroup.Children.GET.Schemas.Response.Children.Payload,
-          SkillGroupResponseSchemaGETHistory: SkillGroup.SkillGroup.History.GET.Schemas.Response.Payload,
           SkillGroupChildrenRequestQueryParamSchemaGET:
             SkillGroup.SkillGroup.Children.GET.Schemas.Request.Query.Payload,
           SkillGroupRequestParamSchemaGET: SkillGroup.SkillGroup.Schemas.Request.Param.Payload,
@@ -487,7 +493,6 @@ function getOpenAPISpecification(
           SkillRelatedRequestSchemaPOST: Skill.Skill.RelatedSkills.POST.Schemas.Request.Payload,
           SkillRelatedResponseSchemaPOST: Skill.Skill.RelatedSkills.POST.Schemas.Response.Payload,
           SkillRelatedRequestQueryParamSchemaGET: Skill.Skill.RelatedSkills.GET.Schemas.Request.Query.Payload,
-          SkillResponseSchemaGETHistory: Skill.Skill.History.GET.Schemas.Response.Payload,
         },
         securitySchemes: {
           jwt_auth: {

--- a/backend/openapi/generateOpenApiDoc.ts
+++ b/backend/openapi/generateOpenApiDoc.ts
@@ -23,11 +23,20 @@ ModelInfo.Schemas.POST.Request.Payload.properties.locale.$ref =
   "#" + ModelInfo.Schemas.POST.Request.Payload.properties.locale.$ref;
 ModelInfo.Schemas.GET.Response.Payload.items.properties.locale.$ref =
   "#" + ModelInfo.Schemas.GET.Response.Payload.items.properties.locale.$ref;
+OccupationGroup.OccupationGroup.History.GET.Schemas.Response.Payload.items.properties.model.$ref =
+  "#" + OccupationGroup.OccupationGroup.History.GET.Schemas.Response.Payload.items.properties.model.$ref;
+Occupation.Occupation.History.GET.Schemas.Response.Payload.items.properties.model.$ref =
+  "#" + Occupation.Occupation.History.GET.Schemas.Response.Payload.items.properties.model.$ref;
+SkillGroup.SkillGroup.History.GET.Schemas.Response.Payload.items.properties.model.$ref =
+  "#" + SkillGroup.SkillGroup.History.GET.Schemas.Response.Payload.items.properties.model.$ref;
+Skill.Skill.History.GET.Schemas.Response.Payload.items.properties.model.$ref =
+  "#" + Skill.Skill.History.GET.Schemas.Response.Payload.items.properties.model.$ref;
 
 /**
  * Remove the $id from the schemas as Swagger does not like them.
  * It does not resolve $ref from within the components sections e.g. it will not resolve "$ref": "#/components/schemas/Schema" from ModelInfoResponseSchema
  */
+delete ModelInfo.Schemas.Reference.$id;
 delete ModelInfo.Schemas.POST.Response.Payload.$id;
 delete ModelInfo.Schemas.POST.Request.Payload.$id;
 delete ModelInfo.Schemas.GET.Response.Payload.$id;
@@ -47,9 +56,11 @@ delete OccupationGroup.GET.Schemas.Request.Param.Payload.$id;
 delete OccupationGroup.GET.Schemas.Request.Query.Payload.$id;
 delete OccupationGroup.OccupationGroup.Schemas.Request.Param.Payload.$id;
 delete OccupationGroup.OccupationGroup.GET.Schemas.Response.Payload.$id;
-delete OccupationGroup.OccupationGroup.GET.Schemas.Response.Payload.$id;
 delete OccupationGroup.OccupationGroup.Children.GET.Schemas.Response.Child.Payload.$id;
 delete OccupationGroup.OccupationGroup.Children.GET.Schemas.Response.Children.Payload.$id;
+delete OccupationGroup.OccupationGroup.History.GET.Schemas.Response.Payload.$id;
+delete OccupationGroup.OccupationGroup.Parent.POST.Schemas.Request.Payload.$id;
+delete OccupationGroup.OccupationGroup.Parent.POST.Schemas.Response.Payload.$id;
 delete Occupation.POST.Schemas.Request.Payload.$id;
 delete Occupation.POST.Schemas.Response.Payload.$id;
 delete Occupation.GET.Schemas.Response.Payload.$id;
@@ -58,6 +69,7 @@ delete Occupation.GET.Schemas.Request.Query.Payload.$id;
 delete Occupation.Occupation.GET.Schemas.Request.Param.Payload.$id;
 delete Occupation.Occupation.Parent.GET.Schemas.Response.Payload.$id;
 delete Occupation.Occupation.Parent.POST.Schemas.Request.Payload.$id;
+delete Occupation.Occupation.Parent.POST.Schemas.Response.Payload.$id;
 delete Occupation.Occupation.Children.GET.Schemas.Response.Payload.$id;
 delete Occupation.Occupation.Children.GET.Schemas.Request.Query.Payload.$id;
 delete Occupation.Occupation.Skills.GET.Schemas.Response.Payload.$id;
@@ -67,6 +79,7 @@ delete Occupation.Occupation.PUT.Schemas.Request.Payload.$id;
 delete Occupation.Occupation.PUT.Schemas.Response.Payload.$id;
 delete Occupation.Occupation.PATCH.Schemas.Request.Payload.$id;
 delete Occupation.Occupation.PATCH.Schemas.Response.Payload.$id;
+delete Occupation.Occupation.History.GET.Schemas.Response.Payload.$id;
 delete SkillGroup.POST.Schemas.Request.Param.Payload.$id;
 delete SkillGroup.POST.Schemas.Request.Payload.$id;
 delete SkillGroup.POST.Schemas.Response.Payload.$id;
@@ -83,6 +96,7 @@ delete SkillGroup.SkillGroup.Parent.POST.Schemas.Response.Payload.$id;
 delete SkillGroup.SkillGroup.Children.GET.Schemas.Request.Query.Payload.$id;
 delete SkillGroup.SkillGroup.Children.GET.Schemas.Response.Child.Payload.$id;
 delete SkillGroup.SkillGroup.Children.GET.Schemas.Response.Children.Payload.$id;
+delete SkillGroup.SkillGroup.History.GET.Schemas.Response.Payload.$id;
 delete Skill.POST.Schemas.Request.Payload.$id;
 delete Skill.POST.Schemas.Request.Param.Payload.$id;
 delete Skill.POST.Schemas.Response.Payload.$id;
@@ -105,6 +119,7 @@ delete Skill.Skill.RelatedSkills.GET.Schemas.Response.Payload.$id;
 delete Skill.Skill.RelatedSkills.GET.Schemas.Request.Query.Payload.$id;
 delete Skill.Skill.RelatedSkills.POST.Schemas.Request.Payload.$id;
 delete Skill.Skill.RelatedSkills.POST.Schemas.Response.Payload.$id;
+delete Skill.Skill.History.GET.Schemas.Response.Payload.$id;
 //--------------------------------------------------------------------------------------------------
 // Generate the openapi specification and store it in the build folder.
 //--------------------------------------------------------------------------------------------------
@@ -424,6 +439,7 @@ function getOpenAPISpecification(
           ModelInfoResponseSchemaPOST: ModelInfo.Schemas.POST.Response.Payload,
           ModelInfoRequestSchemaPOST: ModelInfo.Schemas.POST.Request.Payload,
           ModelInfoResponseSchemaGET: ModelInfo.Schemas.GET.Response.Payload,
+          ModelInfoReferenceSchema: ModelInfo.Schemas.Reference,
           LocaleSchema: Locale.Schemas.Payload,
           ImportSchema: Import.Schemas.POST.Request.Payload,
           ExportSchema: Export.Schemas.POST.Request.Payload,
@@ -438,6 +454,7 @@ function getOpenAPISpecification(
           OccupationGroupRequestQueryParamSchemaGET: OccupationGroup.GET.Schemas.Request.Query.Payload,
           OccupationGroupResponseSchemaGET: OccupationGroup.GET.Schemas.Response.Payload,
           OccupationGroupRequestByIdParamSchemaGET: OccupationGroup.OccupationGroup.Schemas.Request.Param.Payload,
+          OccupationGroupParentRequestSchemaPOST: OccupationGroup.OccupationGroup.Parent.POST.Schemas.Request.Payload,
           OccupationRequestSchemaPOST: Occupation.POST.Schemas.Request.Payload,
           OccupationResponseSchemaPOST: Occupation.POST.Schemas.Response.Payload,
           OccupationRequestParamSchemaGET: Occupation.GET.Schemas.Request.Param.Payload,
@@ -446,13 +463,13 @@ function getOpenAPISpecification(
           OccupationResponseSchemaGET: Occupation.GET.Schemas.Response.Payload,
           OccupationResponseSchemaGETParent: Occupation.Occupation.Parent.GET.Schemas.Response.Payload,
           OccupationParentRequestSchemaPOST: Occupation.Occupation.Parent.POST.Schemas.Request.Payload,
+          OccupationParentResponseSchemaPOST: Occupation.Occupation.Parent.POST.Schemas.Response.Payload,
           OccupationResponseSchemaGETChildren: Occupation.Occupation.Children.GET.Schemas.Response.Payload,
           OccupationChildrenRequestQueryParamSchemaGET:
             Occupation.Occupation.Children.GET.Schemas.Request.Query.Payload,
           OccupationResponseSchemaGETSkills: Occupation.Occupation.Skills.GET.Schemas.Response.Payload,
           OccupationSkillsRequestSchemaPOST: Occupation.Occupation.Skills.POST.Schemas.Request.Payload,
           OccupationSkillsRequestQueryParamSchemaGET: Occupation.Occupation.Skills.GET.Schemas.Request.Query.Payload,
-          OccupationResponseSchemaGETHistory: Occupation.Occupation.History.GET.Schemas.Response.Payload,
           OccupationRequestSchemaPUT: Occupation.Occupation.PUT.Schemas.Request.Payload,
           OccupationResponseSchemaPUT: Occupation.Occupation.PUT.Schemas.Response.Payload,
           OccupationRequestSchemaPATCH: Occupation.Occupation.PATCH.Schemas.Request.Payload,
@@ -493,6 +510,10 @@ function getOpenAPISpecification(
           SkillRelatedRequestSchemaPOST: Skill.Skill.RelatedSkills.POST.Schemas.Request.Payload,
           SkillRelatedResponseSchemaPOST: Skill.Skill.RelatedSkills.POST.Schemas.Response.Payload,
           SkillRelatedRequestQueryParamSchemaGET: Skill.Skill.RelatedSkills.GET.Schemas.Request.Query.Payload,
+          OccupationGroupResponseSchemaGETHistory: OccupationGroup.OccupationGroup.History.GET.Schemas.Response.Payload,
+          OccupationResponseSchemaGETHistory: Occupation.Occupation.History.GET.Schemas.Response.Payload,
+          SkillGroupResponseSchemaGETHistory: SkillGroup.SkillGroup.History.GET.Schemas.Response.Payload,
+          SkillResponseSchemaGETHistory: Skill.Skill.History.GET.Schemas.Response.Payload,
         },
         securitySchemes: {
           jwt_auth: {

--- a/backend/src/esco/occupations/POST/index.test.ts
+++ b/backend/src/esco/occupations/POST/index.test.ts
@@ -58,7 +58,8 @@ describe("Test for occupation POST handler", () => {
         getParent: jest.fn().mockResolvedValue(null),
         getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
-        getHistory: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
       } as IOccupationService,
       initialize: jest.fn(),
     } as unknown as ServiceRegistry;
@@ -143,7 +144,8 @@ describe("Test for occupation POST handler", () => {
         getParent: jest.fn(),
         getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
-        getHistory: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;
@@ -268,7 +270,8 @@ describe("Test for occupation POST handler", () => {
         getParent: jest.fn(),
         getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
-        getHistory: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;
@@ -279,7 +282,6 @@ describe("Test for occupation POST handler", () => {
         getModelByUUID: jest.fn(),
         getModels: jest.fn(),
         getHistory: jest.fn(),
-        getModelsByIds: jest.fn(),
       } as IModelRepository;
       jest.spyOn(getRepositoryRegistry(), "modelInfo", "get").mockReturnValue(givenModelInfoRepositoryMock);
 
@@ -421,7 +423,8 @@ describe("Test for occupation POST handler", () => {
         getParent: jest.fn(),
         getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
-        getHistory: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;
@@ -469,7 +472,8 @@ describe("Test for occupation POST handler", () => {
         getParent: jest.fn(),
         getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
-        getHistory: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;
@@ -541,7 +545,8 @@ describe("Test for occupation POST handler", () => {
         getParent: jest.fn(),
         getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
-        getHistory: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;
@@ -587,7 +592,8 @@ describe("Test for occupation POST handler", () => {
         getParent: jest.fn(),
         getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
-        getHistory: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;

--- a/backend/src/esco/occupations/POST/index.test.ts
+++ b/backend/src/esco/occupations/POST/index.test.ts
@@ -60,6 +60,7 @@ describe("Test for occupation POST handler", () => {
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         update: jest.fn(),
         patch: jest.fn(),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as IOccupationService,
       initialize: jest.fn(),
     } as unknown as ServiceRegistry;
@@ -146,6 +147,7 @@ describe("Test for occupation POST handler", () => {
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         update: jest.fn(),
         patch: jest.fn(),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;
@@ -212,6 +214,7 @@ describe("Test for occupation POST handler", () => {
 
         getParent: jest.fn(),
         getChildren: jest.fn(),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -272,6 +275,7 @@ describe("Test for occupation POST handler", () => {
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         update: jest.fn(),
         patch: jest.fn(),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;
@@ -282,6 +286,7 @@ describe("Test for occupation POST handler", () => {
         getModelByUUID: jest.fn(),
         getModels: jest.fn(),
         getHistory: jest.fn(),
+        getModelsByIds: jest.fn(),
       } as IModelRepository;
       jest.spyOn(getRepositoryRegistry(), "modelInfo", "get").mockReturnValue(givenModelInfoRepositoryMock);
 
@@ -425,6 +430,7 @@ describe("Test for occupation POST handler", () => {
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         update: jest.fn(),
         patch: jest.fn(),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;
@@ -474,6 +480,7 @@ describe("Test for occupation POST handler", () => {
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         update: jest.fn(),
         patch: jest.fn(),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;
@@ -547,6 +554,7 @@ describe("Test for occupation POST handler", () => {
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         update: jest.fn(),
         patch: jest.fn(),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;
@@ -594,6 +602,7 @@ describe("Test for occupation POST handler", () => {
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         update: jest.fn(),
         patch: jest.fn(),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as IOccupationService;
       const mockServiceRegistry = mockGetServiceRegistry();
       mockServiceRegistry.occupation = givenOccupationServiceMock;

--- a/backend/src/esco/occupations/[id]/GET/index.test.ts
+++ b/backend/src/esco/occupations/[id]/GET/index.test.ts
@@ -39,6 +39,7 @@ describe("Test for occupation Detail GET handler", () => {
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         update: jest.fn(),
         patch: jest.fn(),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as IOccupationService,
       initialize: jest.fn(),
     } as unknown as ServiceRegistry;
@@ -68,6 +69,7 @@ describe("Test for occupation Detail GET handler", () => {
       const givenOccupationServiceMock = {
         findById: jest.fn().mockResolvedValue(givenOccupation),
         validateModelForOccupation: jest.fn().mockResolvedValue(null),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -94,6 +96,7 @@ describe("Test for occupation Detail GET handler", () => {
       const givenOccupationServiceMock = {
         findById: jest.fn().mockResolvedValue(null),
         validateModelForOccupation: jest.fn().mockResolvedValue(null),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -117,6 +120,7 @@ describe("Test for occupation Detail GET handler", () => {
         validateModelForOccupation: jest
           .fn()
           .mockResolvedValue(ModelForOccupationValidationErrorCode.MODEL_NOT_FOUND_BY_ID),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -140,6 +144,7 @@ describe("Test for occupation Detail GET handler", () => {
         validateModelForOccupation: jest
           .fn()
           .mockResolvedValue(ModelForOccupationValidationErrorCode.FAILED_TO_FETCH_FROM_DB),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -163,6 +168,7 @@ describe("Test for occupation Detail GET handler", () => {
       const givenOccupationServiceMock = {
         findById: jest.fn().mockRejectedValue(new Error("foo")),
         validateModelForOccupation: jest.fn().mockResolvedValue(null),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -182,6 +188,7 @@ describe("Test for occupation Detail GET handler", () => {
       const givenOccupationServiceMock = {
         findById: jest.fn().mockRejectedValue("some string error"),
         validateModelForOccupation: jest.fn().mockResolvedValue(null),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 

--- a/backend/src/esco/occupations/[id]/GET/index.test.ts
+++ b/backend/src/esco/occupations/[id]/GET/index.test.ts
@@ -37,7 +37,8 @@ describe("Test for occupation Detail GET handler", () => {
         getParent: jest.fn().mockResolvedValue(null),
         getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
-        getHistory: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
       } as IOccupationService,
       initialize: jest.fn(),
     } as unknown as ServiceRegistry;

--- a/backend/src/esco/occupations/[id]/PATCH/index.integration.test.ts
+++ b/backend/src/esco/occupations/[id]/PATCH/index.integration.test.ts
@@ -1,0 +1,169 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import "_test_utilities/consoleMock";
+import Ajv, { ValidateFunction } from "ajv";
+import { randomUUID } from "node:crypto";
+import { Connection } from "mongoose";
+
+import OccupationAPISpecs from "api-specifications/esco/occupation";
+
+import { getRandomString } from "_test_utilities/getMockRandomData";
+import { HTTP_VERBS, StatusCodes } from "server/httpUtils";
+import { handler as occupationHandler } from "./index";
+import addFormats from "ajv-formats";
+import { initOnce } from "server/init";
+import { getConnectionManager } from "server/connection/connectionManager";
+import { getTestConfiguration } from "_test_utilities/getTestConfiguration";
+import { getRepositoryRegistry } from "server/repositoryRegistry/repositoryRegistry";
+import { usersRequestContext } from "_test_utilities/dataModel";
+import { getMockStringId } from "_test_utilities/mockMongoId";
+import { getMockRandomOccupationCode } from "_test_utilities/mockOccupationCode";
+import { getMockRandomISCOGroupCode } from "_test_utilities/mockOccupationGroupCode";
+import { ObjectTypes } from "esco/common/objectTypes";
+
+describe("Test for occupation PATCH handler with a DB", () => {
+  const ajv = new Ajv({ validateSchema: true, strict: true, allErrors: true });
+  addFormats(ajv);
+  ajv.addSchema(OccupationAPISpecs.Occupation.PATCH.Schemas.Response.Payload);
+  const validatePATCHResponse: ValidateFunction = ajv.getSchema(
+    OccupationAPISpecs.Occupation.PATCH.Schemas.Response.Payload.$id as string
+  ) as ValidateFunction;
+
+  let dbConnection: Connection | undefined;
+  beforeAll(async () => {
+    const config = getTestConfiguration("OccupationPATCHHandlerTestDB");
+    const configModule = await import("server/config/config");
+    jest.spyOn(configModule, "readEnvironmentConfiguration").mockReturnValue(config);
+    await initOnce();
+    dbConnection = getConnectionManager().getCurrentDBConnection();
+  });
+
+  afterAll(async () => {
+    if (dbConnection) {
+      await dbConnection.dropDatabase();
+      await dbConnection.close();
+    }
+  });
+
+  beforeEach(async () => {
+    if (dbConnection) {
+      await dbConnection.models.OccupationModel.deleteMany({});
+    }
+  });
+
+  test("PATCH should respond with FORBIDDEN when user is not a model manager", async () => {
+    // GIVEN a request from a non-model-manager user
+    const givenEvent = {
+      httpMethod: HTTP_VERBS.PATCH,
+      body: JSON.stringify({ preferredLabel: "Label" }),
+      headers: { "Content-Type": "application/json" },
+      requestContext: usersRequestContext.REGISTED_USER,
+    };
+
+    // WHEN the handler is invoked
+    const actualResponse = await occupationHandler(givenEvent as unknown as APIGatewayProxyEvent);
+
+    // THEN expect FORBIDDEN
+    expect(actualResponse.statusCode).toEqual(StatusCodes.FORBIDDEN);
+  });
+
+  test("PATCH should respond with OK, only update provided fields, and response passes JSON schema validation", async () => {
+    // GIVEN a model exists in the DB
+    const givenModel = await getRepositoryRegistry().modelInfo.create({
+      name: "Test Model",
+      description: "Test Description",
+      locale: { shortCode: "en", name: "English", UUID: randomUUID() },
+      license: "MIT",
+      UUIDHistory: [],
+    });
+    const givenModelId = givenModel.id;
+    const givenOriginalLabel = "Original Label";
+
+    // AND an occupation exists in the DB
+    const givenOccupation = await getRepositoryRegistry().occupation.create({
+      modelId: givenModelId,
+      code: getMockRandomOccupationCode(false),
+      occupationType: ObjectTypes.ESCOOccupation,
+      preferredLabel: givenOriginalLabel,
+      description: getRandomString(OccupationAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+      altLabels: [getRandomString(OccupationAPISpecs.Constants.ALT_LABEL_MAX_LENGTH)],
+      originUri: `http://some/path/${randomUUID()}`,
+      UUIDHistory: [randomUUID()],
+      occupationGroupCode: getMockRandomISCOGroupCode(),
+      definition: getRandomString(OccupationAPISpecs.Constants.DEFINITION_MAX_LENGTH),
+      scopeNote: getRandomString(OccupationAPISpecs.Constants.SCOPE_NOTE_MAX_LENGTH),
+      regulatedProfessionNote: getRandomString(OccupationAPISpecs.Constants.REGULATED_PROFESSION_NOTE_MAX_LENGTH),
+      isLocalized: false,
+    });
+
+    // AND a PATCH payload that only updates description
+    const givenPatchPayload: OccupationAPISpecs.Occupation.PATCH.Types.Request.Payload = {
+      description: "Patched Description Only",
+    };
+    const givenEvent = {
+      httpMethod: HTTP_VERBS.PATCH,
+      body: JSON.stringify(givenPatchPayload),
+      headers: { "Content-Type": "application/json" },
+      requestContext: usersRequestContext.MODEL_MANAGER,
+      path: `/models/${givenModelId}/occupations/${givenOccupation.id}`,
+      pathParameters: { modelId: givenModelId, id: givenOccupation.id },
+    };
+
+    // WHEN the handler is invoked
+    const actualResponse = await occupationHandler(givenEvent as unknown as APIGatewayProxyEvent);
+
+    // THEN expect OK
+    expect(actualResponse.statusCode).toEqual(StatusCodes.OK);
+    // AND the response passes schema validation
+    expect(validatePATCHResponse(JSON.parse(actualResponse.body))).toBeTruthy();
+    const responseBody = JSON.parse(actualResponse.body);
+    // AND description has been updated
+    expect(responseBody.description).toEqual("Patched Description Only");
+    // AND preferredLabel is unchanged
+    expect(responseBody.preferredLabel).toEqual(givenOriginalLabel);
+  });
+
+  test("PATCH should respond with NOT_FOUND when occupation id does not exist", async () => {
+    // GIVEN a model exists
+    const givenModel = await getRepositoryRegistry().modelInfo.create({
+      name: "Test Model",
+      description: "Test Description",
+      locale: { shortCode: "en", name: "English", UUID: randomUUID() },
+      license: "MIT",
+      UUIDHistory: [],
+    });
+    const givenModelId = givenModel.id;
+    const givenNonExistentId = getMockStringId(99);
+    const givenEvent = {
+      httpMethod: HTTP_VERBS.PATCH,
+      body: JSON.stringify({ preferredLabel: "Label" }),
+      headers: { "Content-Type": "application/json" },
+      requestContext: usersRequestContext.MODEL_MANAGER,
+      path: `/models/${givenModelId}/occupations/${givenNonExistentId}`,
+      pathParameters: { modelId: givenModelId, id: givenNonExistentId },
+    };
+
+    // WHEN the handler is invoked
+    const actualResponse = await occupationHandler(givenEvent as unknown as APIGatewayProxyEvent);
+
+    // THEN expect NOT_FOUND
+    expect(actualResponse.statusCode).toEqual(StatusCodes.NOT_FOUND);
+  });
+
+  test("PATCH should respond with BAD_REQUEST when body is null", async () => {
+    // GIVEN a request with null body
+    const givenModelId = getMockStringId(1);
+    const givenEvent = {
+      httpMethod: HTTP_VERBS.PATCH,
+      body: null,
+      headers: { "Content-Type": "application/json" },
+      requestContext: usersRequestContext.MODEL_MANAGER,
+      path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+    };
+
+    // WHEN the handler is invoked
+    const actualResponse = await occupationHandler(givenEvent as unknown as APIGatewayProxyEvent);
+
+    // THEN expect BAD_REQUEST
+    expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+  });
+});

--- a/backend/src/esco/occupations/[id]/PATCH/index.test.ts
+++ b/backend/src/esco/occupations/[id]/PATCH/index.test.ts
@@ -1,0 +1,477 @@
+import "_test_utilities/consoleMock";
+import * as config from "server/config/config";
+import * as transformModule from "../../_shared/transform";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { handler as occupationHandler } from "./index";
+import { HTTP_VERBS, StatusCodes } from "server/httpUtils";
+import { getMockStringId } from "_test_utilities/mockMongoId";
+import OccupationAPISpecs from "api-specifications/esco/occupation";
+import * as authenticatorModule from "auth/authorizer";
+import { usersRequestContext } from "_test_utilities/dataModel";
+import { IOccupation } from "../../_shared/occupation.types";
+import { getIOccupationMockData } from "../../_shared/testDataHelper";
+import {
+  IOccupationService,
+  ModelForOccupationValidationErrorCode,
+  OccupationModelValidationError,
+} from "../../services/occupation.service.types";
+import { getServiceRegistry, ServiceRegistry } from "server/serviceRegistry/serviceRegistry";
+
+const checkRole = jest.spyOn(authenticatorModule, "checkRole");
+const transformSpy = jest.spyOn(transformModule, "transform");
+
+jest.mock("server/serviceRegistry/serviceRegistry");
+const mockGetServiceRegistry = jest.mocked(getServiceRegistry);
+
+describe("Test for occupation PATCH handler", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    checkRole.mockResolvedValue(true);
+    const mockServiceRegistry = {
+      occupation: {
+        create: jest.fn(),
+        findById: jest.fn().mockResolvedValue(null),
+        findPaginated: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+        validateModelForOccupation: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
+        getParent: jest.fn().mockResolvedValue(null),
+        getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+        getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+      } as IOccupationService,
+      initialize: jest.fn(),
+    } as unknown as ServiceRegistry;
+    mockGetServiceRegistry.mockReturnValue(mockServiceRegistry);
+  });
+
+  describe("PATCH /models/{modelId}/occupations/{id}", () => {
+    test("should respond with FORBIDDEN if user is not a model manager", async () => {
+      // GIVEN the user does not have the required role
+      checkRole.mockResolvedValue(false);
+      const givenModelId = getMockStringId(1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ preferredLabel: "New Label" }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+        requestContext: usersRequestContext.REGISTED_USER,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect FORBIDDEN
+      expect(actualResponse.statusCode).toEqual(StatusCodes.FORBIDDEN);
+    });
+
+    test("should respond with OK and the updated occupation when only preferredLabel is provided", async () => {
+      // GIVEN a partial request with only preferredLabel
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload: OccupationAPISpecs.Occupation.PATCH.Types.Request.Payload = {
+        preferredLabel: "Updated Preferred Label",
+      };
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND a configured base URL
+      const givenBaseUrl = "https://some/path/to/api/resources";
+      jest.spyOn(config, "getResourcesBaseUrl").mockReturnValueOnce(givenBaseUrl);
+
+      // AND the service returns the updated occupation
+      const givenOccupation: IOccupation = getIOccupationMockData();
+      const givenOccupationServiceMock = {
+        patch: jest.fn().mockResolvedValue(givenOccupation),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect OK
+      expect(actualResponse.statusCode).toEqual(StatusCodes.OK);
+      // AND expect transform called correctly
+      expect(transformModule.transform).toHaveBeenCalledWith(givenOccupation, givenBaseUrl);
+      // AND expect the response body
+      expect(JSON.parse(actualResponse.body)).toMatchObject(transformSpy.mock.results[0].value);
+      // AND service.patch called with only the provided fields
+      expect(givenOccupationServiceMock.patch).toHaveBeenCalledWith(
+        givenOccupationId,
+        givenModelId,
+        expect.objectContaining({ preferredLabel: "Updated Preferred Label" })
+      );
+    });
+
+    test("should respond with OK when an empty patch body is sent", async () => {
+      // GIVEN an empty payload ({}), which is valid for PATCH
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({}),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND the service returns the occupation unchanged
+      const givenOccupation: IOccupation = getIOccupationMockData();
+      const givenOccupationServiceMock = {
+        patch: jest.fn().mockResolvedValue(givenOccupation),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect OK
+      expect(actualResponse.statusCode).toEqual(StatusCodes.OK);
+    });
+
+    test("should respond with NOT_FOUND when occupation is not found", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ preferredLabel: "Label" }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND the service returns null (occupation not found)
+      const givenOccupationServiceMock = {
+        patch: jest.fn().mockResolvedValue(null),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect NOT_FOUND
+      expect(actualResponse.statusCode).toEqual(StatusCodes.NOT_FOUND);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(
+        OccupationAPISpecs.Occupation.PATCH.Errors.Status404.ErrorCodes.OCCUPATION_NOT_FOUND
+      );
+    });
+
+    test("should respond with NOT_FOUND when model is not found", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ preferredLabel: "Label" }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND service throws MODEL_NOT_FOUND
+      const givenOccupationServiceMock = {
+        patch: jest
+          .fn()
+          .mockRejectedValue(
+            new OccupationModelValidationError(ModelForOccupationValidationErrorCode.MODEL_NOT_FOUND_BY_ID)
+          ),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect NOT_FOUND
+      expect(actualResponse.statusCode).toEqual(StatusCodes.NOT_FOUND);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(OccupationAPISpecs.Occupation.PATCH.Errors.Status404.ErrorCodes.MODEL_NOT_FOUND);
+    });
+
+    test("should respond with BAD_REQUEST when model is released", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ preferredLabel: "Label" }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND service throws MODEL_IS_RELEASED
+      const givenOccupationServiceMock = {
+        patch: jest
+          .fn()
+          .mockRejectedValue(
+            new OccupationModelValidationError(ModelForOccupationValidationErrorCode.MODEL_IS_RELEASED)
+          ),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(
+        OccupationAPISpecs.Occupation.PATCH.Errors.Status400.ErrorCodes.UNABLE_TO_ALTER_RELEASED_MODEL
+      );
+    });
+
+    test("should respond with BAD_REQUEST when body is null", async () => {
+      // GIVEN a request with null body
+      const givenModelId = getMockStringId(1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: null,
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    });
+
+    test("should respond with TOO_LARGE_PAYLOAD when payload exceeds size limit", async () => {
+      // GIVEN a payload that is too large
+      const givenModelId = getMockStringId(1);
+      const largePayload = "x".repeat(OccupationAPISpecs.Occupation.PATCH.Constants.MAX_PATCH_PAYLOAD_LENGTH + 1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: largePayload,
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect TOO_LARGE_PAYLOAD
+      expect(actualResponse.statusCode).toEqual(StatusCodes.TOO_LARGE_PAYLOAD);
+    });
+
+    test("should respond with UNSUPPORTED_MEDIA_TYPE when Content-Type is wrong", async () => {
+      // GIVEN a request with wrong Content-Type
+      const givenModelId = getMockStringId(1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: "{}",
+        headers: { "Content-Type": "text/plain" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect UNSUPPORTED_MEDIA_TYPE
+      expect(actualResponse.statusCode).toEqual(StatusCodes.UNSUPPORTED_MEDIA_TYPE);
+    });
+
+    test("should respond with INTERNAL_SERVER_ERROR when service throws an unexpected error", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ preferredLabel: "Label" }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND service throws an unexpected error
+      const givenOccupationServiceMock = {
+        patch: jest.fn().mockRejectedValue(new Error("unexpected")),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect INTERNAL_SERVER_ERROR
+      expect(actualResponse.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(
+        OccupationAPISpecs.Occupation.PATCH.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION
+      );
+    });
+
+    test("should only send provided fields to service, not undefined ones", async () => {
+      // GIVEN a partial payload with only description
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = { description: "New Description Only" };
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      const givenOccupation: IOccupation = getIOccupationMockData();
+      const givenOccupationServiceMock = {
+        patch: jest.fn().mockResolvedValue(givenOccupation),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      await occupationHandler(givenEvent);
+
+      // THEN the spec passed to service should only contain description
+      const callArgs = (givenOccupationServiceMock.patch as jest.Mock).mock.calls[0];
+      const passedSpec = callArgs[2]; // third arg is spec
+      expect(passedSpec).toEqual({ description: "New Description Only" });
+      // AND should NOT contain preferredLabel, code, etc.
+      expect(passedSpec).not.toHaveProperty("preferredLabel");
+      expect(passedSpec).not.toHaveProperty("code");
+    });
+
+    test("should respond with INTERNAL_SERVER_ERROR when FAILED_TO_FETCH_FROM_DB", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ preferredLabel: "Label" }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND service throws FAILED_TO_FETCH_FROM_DB
+      const givenOccupationServiceMock = {
+        patch: jest
+          .fn()
+          .mockRejectedValue(
+            new OccupationModelValidationError(ModelForOccupationValidationErrorCode.FAILED_TO_FETCH_FROM_DB)
+          ),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect INTERNAL_SERVER_ERROR
+      expect(actualResponse.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(
+        OccupationAPISpecs.Occupation.PATCH.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION
+      );
+    });
+
+    test("should respond with BAD_REQUEST when JSON body is malformed", async () => {
+      // GIVEN a request with invalid JSON
+      const givenModelId = getMockStringId(1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: "not valid json",
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    });
+
+    test("should respond with BAD_REQUEST when payload fails AJV validation", async () => {
+      // GIVEN a request with an invalid payload
+      const givenModelId = getMockStringId(1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ occupationType: "InvalidType" }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    });
+
+    test("should respond with BAD_REQUEST when path params are invalid", async () => {
+      // GIVEN a request with an invalid occupation ID in path
+      const givenModelId = getMockStringId(1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ preferredLabel: "Label" }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/invalid-id`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    });
+
+    test("should include occupationType mapping when occupationType is provided", async () => {
+      // GIVEN a PATCH request that includes occupationType
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = {
+        occupationType: OccupationAPISpecs.Enums.OccupationType.LocalOccupation,
+        preferredLabel: "Local Label",
+      };
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      const givenOccupation: IOccupation = getIOccupationMockData();
+      const givenOccupationServiceMock = {
+        patch: jest.fn().mockResolvedValue(givenOccupation),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect OK
+      expect(actualResponse.statusCode).toEqual(StatusCodes.OK);
+    });
+
+    test("should respond with INTERNAL_SERVER_ERROR for unknown OccupationModelValidationError code", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ preferredLabel: "Label" }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND service throws OccupationModelValidationError with an unknown code
+      const unknownError = Object.assign(
+        new OccupationModelValidationError(ModelForOccupationValidationErrorCode.MODEL_IS_RELEASED),
+        { code: 999 as unknown as ModelForOccupationValidationErrorCode }
+      );
+      const givenOccupationServiceMock = {
+        patch: jest.fn().mockRejectedValue(unknownError),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect INTERNAL_SERVER_ERROR
+      expect(actualResponse.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(
+        OccupationAPISpecs.Occupation.PATCH.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION
+      );
+    });
+  });
+});

--- a/backend/src/esco/occupations/[id]/PATCH/index.test.ts
+++ b/backend/src/esco/occupations/[id]/PATCH/index.test.ts
@@ -39,6 +39,7 @@ describe("Test for occupation PATCH handler", () => {
         getParent: jest.fn().mockResolvedValue(null),
         getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as IOccupationService,
       initialize: jest.fn(),
     } as unknown as ServiceRegistry;
@@ -87,6 +88,7 @@ describe("Test for occupation PATCH handler", () => {
       const givenOccupation: IOccupation = getIOccupationMockData();
       const givenOccupationServiceMock = {
         patch: jest.fn().mockResolvedValue(givenOccupation),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -122,6 +124,7 @@ describe("Test for occupation PATCH handler", () => {
       const givenOccupation: IOccupation = getIOccupationMockData();
       const givenOccupationServiceMock = {
         patch: jest.fn().mockResolvedValue(givenOccupation),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -146,6 +149,7 @@ describe("Test for occupation PATCH handler", () => {
       // AND the service returns null (occupation not found)
       const givenOccupationServiceMock = {
         patch: jest.fn().mockResolvedValue(null),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -178,6 +182,7 @@ describe("Test for occupation PATCH handler", () => {
           .mockRejectedValue(
             new OccupationModelValidationError(ModelForOccupationValidationErrorCode.MODEL_NOT_FOUND_BY_ID)
           ),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -208,6 +213,7 @@ describe("Test for occupation PATCH handler", () => {
           .mockRejectedValue(
             new OccupationModelValidationError(ModelForOccupationValidationErrorCode.MODEL_IS_RELEASED)
           ),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 

--- a/backend/src/esco/occupations/[id]/PATCH/index.test.ts
+++ b/backend/src/esco/occupations/[id]/PATCH/index.test.ts
@@ -6,6 +6,7 @@ import { handler as occupationHandler } from "./index";
 import { HTTP_VERBS, StatusCodes } from "server/httpUtils";
 import { getMockStringId } from "_test_utilities/mockMongoId";
 import OccupationAPISpecs from "api-specifications/esco/occupation";
+import { ObjectTypes } from "esco/common/objectTypes";
 import * as authenticatorModule from "auth/authorizer";
 import { usersRequestContext } from "_test_utilities/dataModel";
 import { IOccupation } from "../../_shared/occupation.types";
@@ -472,6 +473,154 @@ describe("Test for occupation PATCH handler", () => {
       expect(body.errorCode).toEqual(
         OccupationAPISpecs.Occupation.PATCH.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION
       );
+    });
+
+    test("should respond with BAD_REQUEST when payload modelId does not match path modelId", async () => {
+      // GIVEN a request with mismatched modelId
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ modelId: getMockStringId(99) }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    });
+
+    test("should pass all provided fields through to the service", async () => {
+      // GIVEN a PATCH request with all mutable fields
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = {
+        code: "1234.5.6",
+        occupationGroupCode: "1234",
+        preferredLabel: "New Label",
+        originUri: "http://example.com/new",
+        altLabels: ["alt1", "alt2"],
+        definition: "New Definition",
+        description: "New Description",
+        regulatedProfessionNote: "New Note",
+        scopeNote: "New Scope",
+        modelId: givenModelId,
+        UUIDHistory: ["550e8400-e29b-41d4-a716-446655440000"],
+        isLocalized: true,
+        occupationType: OccupationAPISpecs.Enums.OccupationType.ESCOOccupation,
+      };
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      const givenOccupation: IOccupation = getIOccupationMockData();
+      const givenOccupationServiceMock = {
+        patch: jest.fn().mockResolvedValue(givenOccupation),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect OK
+      expect(actualResponse.statusCode).toEqual(StatusCodes.OK);
+      // AND all fields are passed to the service
+      const callArgs = (givenOccupationServiceMock.patch as jest.Mock).mock.calls[0];
+      const passedSpec = callArgs[2];
+      expect(passedSpec).toMatchObject({
+        code: "1234.5.6",
+        occupationGroupCode: "1234",
+        preferredLabel: "New Label",
+        originUri: "http://example.com/new",
+        altLabels: ["alt1", "alt2"],
+        definition: "New Definition",
+        description: "New Description",
+        regulatedProfessionNote: "New Note",
+        scopeNote: "New Scope",
+        modelId: givenModelId,
+        UUIDHistory: ["550e8400-e29b-41d4-a716-446655440000"],
+        isLocalized: true,
+        occupationType: ObjectTypes.ESCOOccupation,
+      });
+    });
+
+    test("should map ESCOOccupation enum to ObjectTypes.ESCOOccupation", async () => {
+      // GIVEN a PATCH request with ESCOOccupation type
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ occupationType: OccupationAPISpecs.Enums.OccupationType.ESCOOccupation }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      const givenOccupation: IOccupation = getIOccupationMockData();
+      const givenOccupationServiceMock = {
+        patch: jest.fn().mockResolvedValue(givenOccupation),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN
+      await occupationHandler(givenEvent);
+
+      // THEN occupationType is mapped
+      const callArgs = (givenOccupationServiceMock.patch as jest.Mock).mock.calls[0];
+      expect(callArgs[2].occupationType).toEqual(ObjectTypes.ESCOOccupation);
+    });
+
+    test("should map LocalOccupation enum to ObjectTypes.LocalOccupation", async () => {
+      // GIVEN a PATCH request with LocalOccupation type
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: JSON.stringify({ occupationType: OccupationAPISpecs.Enums.OccupationType.LocalOccupation }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      const givenOccupation: IOccupation = getIOccupationMockData();
+      const givenOccupationServiceMock = {
+        patch: jest.fn().mockResolvedValue(givenOccupation),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN
+      await occupationHandler(givenEvent);
+
+      // THEN occupationType is mapped to LocalOccupation
+      const callArgs = (givenOccupationServiceMock.patch as jest.Mock).mock.calls[0];
+      expect(callArgs[2].occupationType).toEqual(ObjectTypes.LocalOccupation);
+    });
+
+    test("should respond with BAD_REQUEST when JSON parse throws a non-Error", async () => {
+      // GIVEN a body that will cause JSON.parse to throw something other than an Error
+      const givenModelId = getMockStringId(1);
+      const originalJSONParse = JSON.parse;
+      JSON.parse = jest.fn().mockImplementation(() => {
+        throw "string error message";
+      });
+
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PATCH,
+        body: "something",
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+      JSON.parse = originalJSONParse;
     });
   });
 });

--- a/backend/src/esco/occupations/[id]/PATCH/index.ts
+++ b/backend/src/esco/occupations/[id]/PATCH/index.ts
@@ -1,0 +1,192 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { APIGatewayProxyResult } from "aws-lambda/trigger/api-gateway-proxy";
+import { errorResponse, responseJSON, StatusCodes } from "server/httpUtils";
+import { getServiceRegistry } from "server/serviceRegistry/serviceRegistry";
+
+import AuthAPISpecs from "api-specifications/auth";
+import OccupationAPISpecs from "api-specifications/esco/occupation";
+import { buildPATCHResponse } from "./response";
+import { parseAndValidatePATCHRequest } from "./request";
+import { getResourcesBaseUrl } from "server/config/config";
+import { IPartialUpdateOccupationSpec } from "../../_shared/occupation.types";
+import { Routes } from "routes.constant";
+import { RoleRequired } from "auth/authorizer";
+import { ObjectTypes } from "esco/common/objectTypes";
+import {
+  ModelForOccupationValidationErrorCode,
+  OccupationModelValidationError,
+} from "../../services/occupation.service.types";
+import { extractAndValidateIdParams } from "../../_shared/params";
+
+export class OccupationPATCHController {
+  /**
+   * @openapi
+   *
+   * /models/{modelId}/occupations/{id}:
+   *   patch:
+   *     operationId: PATCHOccupationById
+   *     tags:
+   *       - occupations
+   *     summary: Partially update an occupation by its ID.
+   *     description: Update one or more fields of an existing occupation in a specific taxonomy model. Only provided fields are updated.
+   *     security:
+   *       - api_key: []
+   *       - jwt_auth: []
+   *     parameters:
+   *       - in: path
+   *         name: modelId
+   *         required: true
+   *         schema:
+   *           $ref: '#/components/schemas/OccupationRequestParamSchemaGET/properties/modelId'
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *           description: The unique ID of the occupation to update.
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/components/schemas/OccupationRequestSchemaPATCH'
+   *       required: true
+   *     responses:
+   *       '200':
+   *         description: Successfully updated the occupation.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/OccupationResponseSchemaPATCH'
+   *       '400':
+   *         description: |
+   *           Failed to update the occupation. Additional information can be found in the response body.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/PATCHOccupation400ErrorSchema'
+   *       '401':
+   *         $ref: '#/components/responses/UnAuthorizedResponse'
+   *       '403':
+   *         description: |
+   *           The request has not been applied because you don't have the right permissions to access this resource.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/AllForbidden403ResponseSchema'
+   *       '404':
+   *         description: Occupation or model not found.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/PATCHOccupation404ErrorSchema'
+   *       '415':
+   *         description: |
+   *           The request is not supported because the media type is not acceptable.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/AllContentType415ResponseSchema'
+   *       '500':
+   *         description: |
+   *           The server encountered an unexpected condition.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/All500ResponseSchema'
+   *
+   */
+  @RoleRequired(AuthAPISpecs.Enums.TabiyaRoles.MODEL_MANAGER)
+  async patch(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+    const parsedRequestResult = parseAndValidatePATCHRequest(event);
+    if ("statusCode" in parsedRequestResult) {
+      return parsedRequestResult;
+    }
+    const payload = parsedRequestResult;
+
+    const params = extractAndValidateIdParams(event, Routes.OCCUPATION_ROUTE);
+    if ("statusCode" in params) {
+      return params;
+    }
+
+    // Build partial spec — only include fields explicitly present in the payload
+    const spec: IPartialUpdateOccupationSpec = {};
+    if (payload.code !== undefined) spec.code = payload.code;
+    if (payload.occupationGroupCode !== undefined) spec.occupationGroupCode = payload.occupationGroupCode;
+    if (payload.preferredLabel !== undefined) spec.preferredLabel = payload.preferredLabel;
+    if (payload.originUri !== undefined) spec.originUri = payload.originUri;
+    if (payload.altLabels !== undefined) spec.altLabels = payload.altLabels;
+    if (payload.definition !== undefined) spec.definition = payload.definition;
+    if (payload.description !== undefined) spec.description = payload.description;
+    if (payload.regulatedProfessionNote !== undefined) spec.regulatedProfessionNote = payload.regulatedProfessionNote;
+    if (payload.scopeNote !== undefined) spec.scopeNote = payload.scopeNote;
+    if (payload.modelId !== undefined) spec.modelId = payload.modelId;
+    if (payload.UUIDHistory !== undefined) spec.UUIDHistory = payload.UUIDHistory;
+    if (payload.isLocalized !== undefined) spec.isLocalized = payload.isLocalized;
+    if (payload.occupationType !== undefined) {
+      spec.occupationType =
+        payload.occupationType === OccupationAPISpecs.Enums.OccupationType.ESCOOccupation
+          ? ObjectTypes.ESCOOccupation
+          : ObjectTypes.LocalOccupation;
+    }
+
+    try {
+      const service = getServiceRegistry().occupation;
+      const updatedOccupation = await service.patch(params.id, params.modelId, spec);
+      if (!updatedOccupation) {
+        return errorResponse(
+          StatusCodes.NOT_FOUND,
+          OccupationAPISpecs.Occupation.PATCH.Errors.Status404.ErrorCodes.OCCUPATION_NOT_FOUND,
+          "Occupation not found",
+          `No occupation found with id: ${params.id}`
+        );
+      }
+      return responseJSON(StatusCodes.OK, buildPATCHResponse(updatedOccupation, getResourcesBaseUrl()));
+    } catch (error: unknown) {
+      console.error("Failed to patch occupation:", error);
+
+      if (error instanceof OccupationModelValidationError) {
+        switch (error.code) {
+          case ModelForOccupationValidationErrorCode.MODEL_NOT_FOUND_BY_ID:
+            return errorResponse(
+              StatusCodes.NOT_FOUND,
+              OccupationAPISpecs.Occupation.PATCH.Errors.Status404.ErrorCodes.MODEL_NOT_FOUND,
+              "Model not found by the provided ID",
+              ""
+            );
+          case ModelForOccupationValidationErrorCode.MODEL_IS_RELEASED:
+            return errorResponse(
+              StatusCodes.BAD_REQUEST,
+              OccupationAPISpecs.Occupation.PATCH.Errors.Status400.ErrorCodes.UNABLE_TO_ALTER_RELEASED_MODEL,
+              "Cannot update occupations in a released model",
+              ""
+            );
+          case ModelForOccupationValidationErrorCode.FAILED_TO_FETCH_FROM_DB:
+            return errorResponse(
+              StatusCodes.INTERNAL_SERVER_ERROR,
+              OccupationAPISpecs.Occupation.PATCH.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION,
+              "Failed to fetch the model details from the DB",
+              ""
+            );
+          default:
+            return errorResponse(
+              StatusCodes.INTERNAL_SERVER_ERROR,
+              OccupationAPISpecs.Occupation.PATCH.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION,
+              "Failed to update the occupation in the DB",
+              ""
+            );
+        }
+      } else {
+        return errorResponse(
+          StatusCodes.INTERNAL_SERVER_ERROR,
+          OccupationAPISpecs.Occupation.PATCH.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION,
+          "Failed to update the occupation in the DB",
+          ""
+        );
+      }
+    }
+  }
+}
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  return new OccupationPATCHController().patch(event);
+};

--- a/backend/src/esco/occupations/[id]/PATCH/index.ts
+++ b/backend/src/esco/occupations/[id]/PATCH/index.ts
@@ -108,6 +108,15 @@ export class OccupationPATCHController {
       return params;
     }
 
+    if (payload.modelId !== undefined && payload.modelId !== params.modelId) {
+      return errorResponse(
+        StatusCodes.BAD_REQUEST,
+        OccupationAPISpecs.Occupation.PATCH.Errors.Status400.ErrorCodes.INVALID_MODEL_ID,
+        "modelId in payload does not match modelId in path",
+        `Payload modelId: ${payload.modelId}, Path modelId: ${params.modelId}`
+      );
+    }
+
     // Build partial spec — only include fields explicitly present in the payload
     const spec: IPartialUpdateOccupationSpec = {};
     if (payload.code !== undefined) spec.code = payload.code;

--- a/backend/src/esco/occupations/[id]/PATCH/request.ts
+++ b/backend/src/esco/occupations/[id]/PATCH/request.ts
@@ -1,0 +1,43 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { STD_ERRORS_RESPONSES } from "server/httpUtils";
+import { ajvInstance, ParseValidationError } from "validator";
+import { ValidateFunction } from "ajv";
+import OccupationAPISpecs from "api-specifications/esco/occupation";
+
+export function parseAndValidatePATCHRequest(
+  event: APIGatewayProxyEvent
+): OccupationAPISpecs.Occupation.PATCH.Types.Request.Payload | APIGatewayProxyResult {
+  if (!event.headers?.["Content-Type"]?.includes("application/json")) {
+    return STD_ERRORS_RESPONSES.UNSUPPORTED_MEDIA_TYPE_ERROR;
+  }
+
+  if (event.body == null) {
+    return STD_ERRORS_RESPONSES.MALFORMED_BODY_ERROR("Body is empty");
+  }
+
+  if (event.body.length > OccupationAPISpecs.Occupation.PATCH.Constants.MAX_PATCH_PAYLOAD_LENGTH) {
+    return STD_ERRORS_RESPONSES.TOO_LARGE_PAYLOAD_ERROR(
+      `Expected maximum length is ${OccupationAPISpecs.Occupation.PATCH.Constants.MAX_PATCH_PAYLOAD_LENGTH}`
+    );
+  }
+
+  let payload: OccupationAPISpecs.Occupation.PATCH.Types.Request.Payload;
+  try {
+    payload = JSON.parse(event.body);
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    return STD_ERRORS_RESPONSES.MALFORMED_BODY_ERROR(errorMessage);
+  }
+
+  const validateFunction = ajvInstance.getSchema(
+    OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload.$id as string
+  ) as ValidateFunction;
+
+  const isValid = validateFunction(payload);
+  if (!isValid) {
+    const errorDetail = ParseValidationError(validateFunction.errors);
+    return STD_ERRORS_RESPONSES.INVALID_JSON_SCHEMA_ERROR(errorDetail);
+  }
+
+  return payload;
+}

--- a/backend/src/esco/occupations/[id]/PATCH/response.ts
+++ b/backend/src/esco/occupations/[id]/PATCH/response.ts
@@ -1,0 +1,6 @@
+import { transform } from "../../_shared/transform";
+import { IOccupation } from "../../_shared/occupation.types";
+
+export function buildPATCHResponse(occupation: IOccupation, baseURL: string) {
+  return transform(occupation, baseURL);
+}

--- a/backend/src/esco/occupations/[id]/PUT/index.integration.test.ts
+++ b/backend/src/esco/occupations/[id]/PUT/index.integration.test.ts
@@ -1,0 +1,190 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import "_test_utilities/consoleMock";
+import Ajv, { ValidateFunction } from "ajv";
+import { randomUUID } from "node:crypto";
+import { Connection } from "mongoose";
+
+import OccupationAPISpecs from "api-specifications/esco/occupation";
+
+import { getRandomString } from "_test_utilities/getMockRandomData";
+import { HTTP_VERBS, StatusCodes } from "server/httpUtils";
+import { handler as occupationHandler } from "./index";
+import addFormats from "ajv-formats";
+import { initOnce } from "server/init";
+import { getConnectionManager } from "server/connection/connectionManager";
+import { getTestConfiguration } from "_test_utilities/getTestConfiguration";
+import { getRepositoryRegistry } from "server/repositoryRegistry/repositoryRegistry";
+import { usersRequestContext } from "_test_utilities/dataModel";
+import { getMockStringId } from "_test_utilities/mockMongoId";
+import { getMockRandomOccupationCode } from "_test_utilities/mockOccupationCode";
+import { getMockRandomISCOGroupCode } from "_test_utilities/mockOccupationGroupCode";
+import { ObjectTypes } from "esco/common/objectTypes";
+
+describe("Test for occupation PUT handler with a DB", () => {
+  const ajv = new Ajv({ validateSchema: true, strict: true, allErrors: true });
+  addFormats(ajv);
+  ajv.addSchema(OccupationAPISpecs.Occupation.PUT.Schemas.Response.Payload);
+  const validatePUTResponse: ValidateFunction = ajv.getSchema(
+    OccupationAPISpecs.Occupation.PUT.Schemas.Response.Payload.$id as string
+  ) as ValidateFunction;
+
+  let dbConnection: Connection | undefined;
+  beforeAll(async () => {
+    const config = getTestConfiguration("OccupationPUTHandlerTestDB");
+    const configModule = await import("server/config/config");
+    jest.spyOn(configModule, "readEnvironmentConfiguration").mockReturnValue(config);
+    await initOnce();
+    dbConnection = getConnectionManager().getCurrentDBConnection();
+  });
+
+  afterAll(async () => {
+    if (dbConnection) {
+      await dbConnection.dropDatabase();
+      await dbConnection.close();
+    }
+  });
+
+  beforeEach(async () => {
+    if (dbConnection) {
+      await dbConnection.models.OccupationModel.deleteMany({});
+    }
+  });
+
+  test("PUT should respond with FORBIDDEN when user is not a model manager", async () => {
+    // GIVEN a request from a non-model-manager user
+    const givenModelId = getMockStringId(1);
+    const givenPayload: OccupationAPISpecs.Occupation.PUT.Types.Request.Payload = {
+      modelId: givenModelId,
+      code: getMockRandomOccupationCode(false),
+      occupationType: OccupationAPISpecs.Enums.OccupationType.ESCOOccupation,
+      preferredLabel: getRandomString(OccupationAPISpecs.Constants.PREFERRED_LABEL_MAX_LENGTH),
+      description: getRandomString(OccupationAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+      altLabels: [getRandomString(OccupationAPISpecs.Constants.ALT_LABEL_MAX_LENGTH)],
+      originUri: `http://some/path/${randomUUID()}`,
+      UUIDHistory: [randomUUID()],
+      occupationGroupCode: getMockRandomISCOGroupCode(),
+      definition: getRandomString(OccupationAPISpecs.Constants.DEFINITION_MAX_LENGTH),
+      scopeNote: getRandomString(OccupationAPISpecs.Constants.SCOPE_NOTE_MAX_LENGTH),
+      regulatedProfessionNote: getRandomString(OccupationAPISpecs.Constants.REGULATED_PROFESSION_NOTE_MAX_LENGTH),
+      isLocalized: false,
+    };
+    const givenEvent = {
+      httpMethod: HTTP_VERBS.PUT,
+      body: JSON.stringify(givenPayload),
+      headers: { "Content-Type": "application/json" },
+      requestContext: usersRequestContext.REGISTED_USER,
+    };
+
+    // WHEN the handler is invoked
+    const actualResponse = await occupationHandler(givenEvent as unknown as APIGatewayProxyEvent);
+
+    // THEN expect FORBIDDEN
+    expect(actualResponse.statusCode).toEqual(StatusCodes.FORBIDDEN);
+  });
+
+  test("PUT should respond with OK and response passes JSON schema validation", async () => {
+    // GIVEN a model exists in the DB
+    const givenModel = await getRepositoryRegistry().modelInfo.create({
+      name: "Test Model",
+      description: "Test Description",
+      locale: { shortCode: "en", name: "English", UUID: randomUUID() },
+      license: "MIT",
+      UUIDHistory: [],
+    });
+    const givenModelId = givenModel.id;
+
+    // AND an occupation exists in the DB
+    const givenOccupation = await getRepositoryRegistry().occupation.create({
+      modelId: givenModelId,
+      code: getMockRandomOccupationCode(false),
+      occupationType: ObjectTypes.ESCOOccupation,
+      preferredLabel: getRandomString(OccupationAPISpecs.Constants.PREFERRED_LABEL_MAX_LENGTH),
+      description: getRandomString(OccupationAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+      altLabels: [getRandomString(OccupationAPISpecs.Constants.ALT_LABEL_MAX_LENGTH)],
+      originUri: `http://some/path/${randomUUID()}`,
+      UUIDHistory: [randomUUID()],
+      occupationGroupCode: getMockRandomISCOGroupCode(),
+      definition: getRandomString(OccupationAPISpecs.Constants.DEFINITION_MAX_LENGTH),
+      scopeNote: getRandomString(OccupationAPISpecs.Constants.SCOPE_NOTE_MAX_LENGTH),
+      regulatedProfessionNote: getRandomString(OccupationAPISpecs.Constants.REGULATED_PROFESSION_NOTE_MAX_LENGTH),
+      isLocalized: false,
+    });
+
+    // AND a valid PUT payload with updated data
+    const givenNewPayload: OccupationAPISpecs.Occupation.PUT.Types.Request.Payload = {
+      modelId: givenModelId,
+      code: getMockRandomOccupationCode(false),
+      occupationType: OccupationAPISpecs.Enums.OccupationType.ESCOOccupation,
+      preferredLabel: "Updated Label",
+      description: "Updated Description",
+      altLabels: [],
+      originUri: `http://some/path/${randomUUID()}`,
+      UUIDHistory: [randomUUID()],
+      occupationGroupCode: getMockRandomISCOGroupCode(),
+      definition: "Updated Definition",
+      scopeNote: "Updated Scope",
+      regulatedProfessionNote: "Updated Note",
+      isLocalized: false,
+    };
+    const givenEvent = {
+      httpMethod: HTTP_VERBS.PUT,
+      body: JSON.stringify(givenNewPayload),
+      headers: { "Content-Type": "application/json" },
+      requestContext: usersRequestContext.MODEL_MANAGER,
+      path: `/models/${givenModelId}/occupations/${givenOccupation.id}`,
+      pathParameters: { modelId: givenModelId, id: givenOccupation.id },
+    };
+
+    // WHEN the handler is invoked
+    const actualResponse = await occupationHandler(givenEvent as unknown as APIGatewayProxyEvent);
+
+    // THEN expect OK
+    expect(actualResponse.statusCode).toEqual(StatusCodes.OK);
+    // AND the response passes schema validation
+    expect(validatePUTResponse(JSON.parse(actualResponse.body))).toBeTruthy();
+    // AND the preferred label has been updated
+    expect(JSON.parse(actualResponse.body).preferredLabel).toEqual("Updated Label");
+  });
+
+  test("PUT should respond with NOT_FOUND when occupation id does not exist", async () => {
+    // GIVEN a model exists
+    const givenModel = await getRepositoryRegistry().modelInfo.create({
+      name: "Test Model",
+      description: "Test Description",
+      locale: { shortCode: "en", name: "English", UUID: randomUUID() },
+      license: "MIT",
+      UUIDHistory: [],
+    });
+    const givenModelId = givenModel.id;
+    const givenNonExistentId = getMockStringId(99);
+    const givenPayload: OccupationAPISpecs.Occupation.PUT.Types.Request.Payload = {
+      modelId: givenModelId,
+      code: getMockRandomOccupationCode(false),
+      occupationType: OccupationAPISpecs.Enums.OccupationType.ESCOOccupation,
+      preferredLabel: "Label",
+      description: "Desc",
+      altLabels: [],
+      originUri: `http://some/path/${randomUUID()}`,
+      UUIDHistory: [randomUUID()],
+      occupationGroupCode: getMockRandomISCOGroupCode(),
+      definition: "Def",
+      scopeNote: "Scope",
+      regulatedProfessionNote: "Note",
+      isLocalized: false,
+    };
+    const givenEvent = {
+      httpMethod: HTTP_VERBS.PUT,
+      body: JSON.stringify(givenPayload),
+      headers: { "Content-Type": "application/json" },
+      requestContext: usersRequestContext.MODEL_MANAGER,
+      path: `/models/${givenModelId}/occupations/${givenNonExistentId}`,
+      pathParameters: { modelId: givenModelId, id: givenNonExistentId },
+    };
+
+    // WHEN the handler is invoked
+    const actualResponse = await occupationHandler(givenEvent as unknown as APIGatewayProxyEvent);
+
+    // THEN expect NOT_FOUND
+    expect(actualResponse.statusCode).toEqual(StatusCodes.NOT_FOUND);
+  });
+});

--- a/backend/src/esco/occupations/[id]/PUT/index.test.ts
+++ b/backend/src/esco/occupations/[id]/PUT/index.test.ts
@@ -58,6 +58,7 @@ describe("Test for occupation PUT handler", () => {
         getParent: jest.fn().mockResolvedValue(null),
         getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
         getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as IOccupationService,
       initialize: jest.fn(),
     } as unknown as ServiceRegistry;
@@ -115,6 +116,7 @@ describe("Test for occupation PUT handler", () => {
         getParent: jest.fn(),
         getChildren: jest.fn(),
         getSkills: jest.fn(),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -147,6 +149,7 @@ describe("Test for occupation PUT handler", () => {
       // AND service returns null (occupation not found)
       const givenOccupationServiceMock = {
         update: jest.fn().mockResolvedValue(null),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -181,6 +184,7 @@ describe("Test for occupation PUT handler", () => {
           .mockRejectedValue(
             new OccupationModelValidationError(ModelForOccupationValidationErrorCode.MODEL_NOT_FOUND_BY_ID)
           ),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 
@@ -213,6 +217,7 @@ describe("Test for occupation PUT handler", () => {
           .mockRejectedValue(
             new OccupationModelValidationError(ModelForOccupationValidationErrorCode.MODEL_IS_RELEASED)
           ),
+        getHistory: jest.fn().mockResolvedValue(null),
       } as unknown as IOccupationService;
       mockGetServiceRegistry().occupation = givenOccupationServiceMock;
 

--- a/backend/src/esco/occupations/[id]/PUT/index.test.ts
+++ b/backend/src/esco/occupations/[id]/PUT/index.test.ts
@@ -1,0 +1,453 @@
+import "_test_utilities/consoleMock";
+import * as config from "server/config/config";
+import * as transformModule from "../../_shared/transform";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { handler as occupationHandler } from "./index";
+import { HTTP_VERBS, StatusCodes } from "server/httpUtils";
+import { getMockStringId } from "_test_utilities/mockMongoId";
+import { randomUUID } from "node:crypto";
+import { getRandomString } from "_test_utilities/getMockRandomData";
+import OccupationAPISpecs from "api-specifications/esco/occupation";
+import * as authenticatorModule from "auth/authorizer";
+import { usersRequestContext } from "_test_utilities/dataModel";
+import { getMockRandomISCOGroupCode } from "_test_utilities/mockOccupationGroupCode";
+import { IOccupation } from "../../_shared/occupation.types";
+import { getIOccupationMockData } from "../../_shared/testDataHelper";
+import { getMockRandomOccupationCode } from "_test_utilities/mockOccupationCode";
+import {
+  IOccupationService,
+  ModelForOccupationValidationErrorCode,
+  OccupationModelValidationError,
+} from "../../services/occupation.service.types";
+import { getServiceRegistry, ServiceRegistry } from "server/serviceRegistry/serviceRegistry";
+
+const checkRole = jest.spyOn(authenticatorModule, "checkRole");
+const transformSpy = jest.spyOn(transformModule, "transform");
+
+jest.mock("server/serviceRegistry/serviceRegistry");
+const mockGetServiceRegistry = jest.mocked(getServiceRegistry);
+
+const givenValidPayload = (): OccupationAPISpecs.Occupation.PUT.Types.Request.Payload => ({
+  modelId: getMockStringId(1),
+  code: getMockRandomOccupationCode(false),
+  occupationType: OccupationAPISpecs.Enums.OccupationType.ESCOOccupation,
+  preferredLabel: getRandomString(OccupationAPISpecs.Constants.PREFERRED_LABEL_MAX_LENGTH),
+  description: getRandomString(OccupationAPISpecs.Constants.DESCRIPTION_MAX_LENGTH),
+  altLabels: [getRandomString(OccupationAPISpecs.Constants.ALT_LABEL_MAX_LENGTH)],
+  originUri: `http://some/path/to/api/resources/${randomUUID()}`,
+  UUIDHistory: [randomUUID()],
+  occupationGroupCode: getMockRandomISCOGroupCode(),
+  definition: getRandomString(OccupationAPISpecs.Constants.DEFINITION_MAX_LENGTH),
+  scopeNote: getRandomString(OccupationAPISpecs.Constants.SCOPE_NOTE_MAX_LENGTH),
+  regulatedProfessionNote: getRandomString(OccupationAPISpecs.Constants.REGULATED_PROFESSION_NOTE_MAX_LENGTH),
+  isLocalized: false,
+});
+
+describe("Test for occupation PUT handler", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    checkRole.mockResolvedValue(true);
+    const mockServiceRegistry = {
+      occupation: {
+        create: jest.fn(),
+        findById: jest.fn().mockResolvedValue(null),
+        findPaginated: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+        validateModelForOccupation: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
+        getParent: jest.fn().mockResolvedValue(null),
+        getChildren: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+        getSkills: jest.fn().mockResolvedValue({ items: [], nextCursor: null }),
+      } as IOccupationService,
+      initialize: jest.fn(),
+    } as unknown as ServiceRegistry;
+    mockGetServiceRegistry.mockReturnValue(mockServiceRegistry);
+  });
+
+  describe("PUT /models/{modelId}/occupations/{id}", () => {
+    test("should respond with FORBIDDEN if user is not a model manager", async () => {
+      // GIVEN the user does not have the required role
+      checkRole.mockResolvedValue(false);
+      const givenModelId = getMockStringId(1);
+      const givenPayload = givenValidPayload();
+      givenPayload.modelId = givenModelId;
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+        requestContext: usersRequestContext.REGISTED_USER,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect FORBIDDEN
+      expect(actualResponse.statusCode).toEqual(StatusCodes.FORBIDDEN);
+    });
+
+    test("should respond with OK and the updated occupation for a valid request", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = givenValidPayload();
+      givenPayload.modelId = givenModelId;
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND a configured base URL
+      const givenBaseUrl = "https://some/path/to/api/resources";
+      jest.spyOn(config, "getResourcesBaseUrl").mockReturnValueOnce(givenBaseUrl);
+
+      // AND the service returns the updated occupation
+      const givenOccupation: IOccupation = getIOccupationMockData();
+      const givenOccupationServiceMock = {
+        update: jest.fn().mockResolvedValue(givenOccupation),
+        patch: jest.fn(),
+        findById: jest.fn(),
+        create: jest.fn(),
+        findPaginated: jest.fn(),
+        validateModelForOccupation: jest.fn(),
+        getParent: jest.fn(),
+        getChildren: jest.fn(),
+        getSkills: jest.fn(),
+      } as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect OK
+      expect(actualResponse.statusCode).toEqual(StatusCodes.OK);
+      // AND expect Content-Type header
+      expect(actualResponse.headers).toMatchObject({ "Content-Type": "application/json" });
+      // AND expect transform to be called correctly
+      expect(transformModule.transform).toHaveBeenCalledWith(givenOccupation, givenBaseUrl);
+      // AND expect the response body
+      expect(JSON.parse(actualResponse.body)).toMatchObject(transformSpy.mock.results[0].value);
+    });
+
+    test("should respond with NOT_FOUND when occupation is not found", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = givenValidPayload();
+      givenPayload.modelId = givenModelId;
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND service returns null (occupation not found)
+      const givenOccupationServiceMock = {
+        update: jest.fn().mockResolvedValue(null),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect NOT_FOUND
+      expect(actualResponse.statusCode).toEqual(StatusCodes.NOT_FOUND);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(
+        OccupationAPISpecs.Occupation.PUT.Errors.Status404.ErrorCodes.OCCUPATION_NOT_FOUND
+      );
+    });
+
+    test("should respond with NOT_FOUND when model is not found", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = givenValidPayload();
+      givenPayload.modelId = givenModelId;
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND service throws MODEL_NOT_FOUND
+      const givenOccupationServiceMock = {
+        update: jest
+          .fn()
+          .mockRejectedValue(
+            new OccupationModelValidationError(ModelForOccupationValidationErrorCode.MODEL_NOT_FOUND_BY_ID)
+          ),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect NOT_FOUND
+      expect(actualResponse.statusCode).toEqual(StatusCodes.NOT_FOUND);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(OccupationAPISpecs.Occupation.PUT.Errors.Status404.ErrorCodes.MODEL_NOT_FOUND);
+    });
+
+    test("should respond with BAD_REQUEST when model is released", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = givenValidPayload();
+      givenPayload.modelId = givenModelId;
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND service throws MODEL_IS_RELEASED
+      const givenOccupationServiceMock = {
+        update: jest
+          .fn()
+          .mockRejectedValue(
+            new OccupationModelValidationError(ModelForOccupationValidationErrorCode.MODEL_IS_RELEASED)
+          ),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(
+        OccupationAPISpecs.Occupation.PUT.Errors.Status400.ErrorCodes.UNABLE_TO_ALTER_RELEASED_MODEL
+      );
+    });
+
+    test("should respond with BAD_REQUEST when modelId in payload does not match path", async () => {
+      // GIVEN a valid request with mismatched modelId
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = givenValidPayload();
+      givenPayload.modelId = getMockStringId(99); // different modelId
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    });
+
+    test("should respond with BAD_REQUEST when body is null", async () => {
+      // GIVEN a request with null body
+      const givenModelId = getMockStringId(1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: null,
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    });
+
+    test("should respond with TOO_LARGE_PAYLOAD when payload exceeds size limit", async () => {
+      // GIVEN a payload that is too large
+      const givenModelId = getMockStringId(1);
+      const largePayload = "x".repeat(OccupationAPISpecs.Occupation.PUT.Constants.MAX_PUT_PAYLOAD_LENGTH + 1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: largePayload,
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect TOO_LARGE_PAYLOAD
+      expect(actualResponse.statusCode).toEqual(StatusCodes.TOO_LARGE_PAYLOAD);
+    });
+
+    test("should respond with UNSUPPORTED_MEDIA_TYPE when Content-Type is wrong", async () => {
+      // GIVEN a request with wrong Content-Type
+      const givenModelId = getMockStringId(1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: "{}",
+        headers: { "Content-Type": "text/plain" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect UNSUPPORTED_MEDIA_TYPE
+      expect(actualResponse.statusCode).toEqual(StatusCodes.UNSUPPORTED_MEDIA_TYPE);
+    });
+
+    test("should respond with INTERNAL_SERVER_ERROR when service throws an unexpected error", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = givenValidPayload();
+      givenPayload.modelId = givenModelId;
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND service throws an unexpected error
+      const givenOccupationServiceMock = {
+        update: jest.fn().mockRejectedValue(new Error("unexpected")),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect INTERNAL_SERVER_ERROR
+      expect(actualResponse.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(
+        OccupationAPISpecs.Occupation.PUT.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION
+      );
+    });
+
+    test("should respond with INTERNAL_SERVER_ERROR when FAILED_TO_FETCH_FROM_DB", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = givenValidPayload();
+      givenPayload.modelId = givenModelId;
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND service throws FAILED_TO_FETCH_FROM_DB
+      const givenOccupationServiceMock = {
+        update: jest
+          .fn()
+          .mockRejectedValue(
+            new OccupationModelValidationError(ModelForOccupationValidationErrorCode.FAILED_TO_FETCH_FROM_DB)
+          ),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect INTERNAL_SERVER_ERROR
+      expect(actualResponse.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(
+        OccupationAPISpecs.Occupation.PUT.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION
+      );
+    });
+
+    test("should respond with BAD_REQUEST when JSON body is malformed", async () => {
+      // GIVEN a request with invalid JSON
+      const givenModelId = getMockStringId(1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: "not valid json",
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    });
+
+    test("should respond with BAD_REQUEST when payload fails AJV validation", async () => {
+      // GIVEN a request with an invalid payload (missing required fields)
+      const givenModelId = getMockStringId(1);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify({ invalidField: "value" }),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    });
+
+    test("should respond with BAD_REQUEST when path params are invalid", async () => {
+      // GIVEN a request with an invalid occupation ID in path
+      const givenModelId = getMockStringId(1);
+      const givenPayload = givenValidPayload();
+      givenPayload.modelId = givenModelId;
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/invalid-id`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    });
+
+    test("should respond with INTERNAL_SERVER_ERROR for unknown OccupationModelValidationError code", async () => {
+      // GIVEN a valid request
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = givenValidPayload();
+      givenPayload.modelId = givenModelId;
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // AND service throws OccupationModelValidationError with an unknown code
+      const unknownError = Object.assign(
+        new OccupationModelValidationError(ModelForOccupationValidationErrorCode.MODEL_IS_RELEASED),
+        { code: 999 as unknown as ModelForOccupationValidationErrorCode }
+      );
+      const givenOccupationServiceMock = {
+        update: jest.fn().mockRejectedValue(unknownError),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect INTERNAL_SERVER_ERROR
+      expect(actualResponse.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+      const body = JSON.parse(actualResponse.body);
+      expect(body.errorCode).toEqual(
+        OccupationAPISpecs.Occupation.PUT.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION
+      );
+    });
+  });
+});

--- a/backend/src/esco/occupations/[id]/PUT/index.test.ts
+++ b/backend/src/esco/occupations/[id]/PUT/index.test.ts
@@ -449,5 +449,56 @@ describe("Test for occupation PUT handler", () => {
         OccupationAPISpecs.Occupation.PUT.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION
       );
     });
+
+    test("should handle LocalOccupation type and map to ObjectTypes.LocalOccupation", async () => {
+      // GIVEN a request with LocalOccupation type
+      const givenModelId = getMockStringId(1);
+      const givenOccupationId = getMockStringId(2);
+      const givenPayload = givenValidPayload();
+      givenPayload.modelId = givenModelId;
+      givenPayload.occupationType = OccupationAPISpecs.Enums.OccupationType.LocalOccupation;
+      givenPayload.code = getMockRandomOccupationCode(true);
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: JSON.stringify(givenPayload),
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${givenOccupationId}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      const givenOccupation: IOccupation = getIOccupationMockData();
+      const givenOccupationServiceMock = {
+        update: jest.fn().mockResolvedValue(givenOccupation),
+      } as unknown as IOccupationService;
+      mockGetServiceRegistry().occupation = givenOccupationServiceMock;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect OK
+      expect(actualResponse.statusCode).toEqual(StatusCodes.OK);
+    });
+
+    test("should respond with BAD_REQUEST when JSON parse throws a non-Error", async () => {
+      // GIVEN a body that will cause JSON.parse to throw something other than an Error
+      const givenModelId = getMockStringId(1);
+      const originalJSONParse = JSON.parse;
+      JSON.parse = jest.fn().mockImplementation(() => {
+        throw "string error message";
+      });
+
+      const givenEvent: APIGatewayProxyEvent = {
+        httpMethod: HTTP_VERBS.PUT,
+        body: "something",
+        headers: { "Content-Type": "application/json" },
+        path: `/models/${givenModelId}/occupations/${getMockStringId(2)}`,
+      } as unknown as APIGatewayProxyEvent;
+
+      // WHEN the handler is invoked
+      const actualResponse = await occupationHandler(givenEvent);
+
+      // THEN expect BAD_REQUEST
+      expect(actualResponse.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+      JSON.parse = originalJSONParse;
+    });
   });
 });

--- a/backend/src/esco/occupations/[id]/PUT/index.ts
+++ b/backend/src/esco/occupations/[id]/PUT/index.ts
@@ -1,0 +1,199 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { APIGatewayProxyResult } from "aws-lambda/trigger/api-gateway-proxy";
+import { errorResponse, responseJSON, StatusCodes } from "server/httpUtils";
+import { getServiceRegistry } from "server/serviceRegistry/serviceRegistry";
+
+import AuthAPISpecs from "api-specifications/auth";
+import OccupationAPISpecs from "api-specifications/esco/occupation";
+import { buildPUTResponse } from "./response";
+import { parseAndValidatePUTRequest } from "./request";
+import { getResourcesBaseUrl } from "server/config/config";
+import { IUpdateOccupationSpec } from "../../_shared/occupation.types";
+import { Routes } from "routes.constant";
+import { RoleRequired } from "auth/authorizer";
+import { ObjectTypes } from "esco/common/objectTypes";
+import {
+  ModelForOccupationValidationErrorCode,
+  OccupationModelValidationError,
+} from "../../services/occupation.service.types";
+import { extractAndValidateIdParams } from "../../_shared/params";
+
+export class OccupationPUTController {
+  /**
+   * @openapi
+   *
+   * /models/{modelId}/occupations/{id}:
+   *   put:
+   *     operationId: PUTOccupationById
+   *     tags:
+   *       - occupations
+   *     summary: Fully replace an occupation by its ID.
+   *     description: Completely replace all mutable fields of an existing occupation in a specific taxonomy model.
+   *     security:
+   *       - api_key: []
+   *       - jwt_auth: []
+   *     parameters:
+   *       - in: path
+   *         name: modelId
+   *         required: true
+   *         schema:
+   *           $ref: '#/components/schemas/OccupationRequestParamSchemaGET/properties/modelId'
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *           description: The unique ID of the occupation to replace.
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/components/schemas/OccupationRequestSchemaPUT'
+   *       required: true
+   *     responses:
+   *       '200':
+   *         description: Successfully replaced the occupation.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/OccupationResponseSchemaPUT'
+   *       '400':
+   *         description: |
+   *           Failed to replace the occupation. Additional information can be found in the response body.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/PUTOccupation400ErrorSchema'
+   *       '401':
+   *         $ref: '#/components/responses/UnAuthorizedResponse'
+   *       '403':
+   *         description: |
+   *           The request has not been applied because you don't have the right permissions to access this resource.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/AllForbidden403ResponseSchema'
+   *       '404':
+   *         description: Occupation or model not found.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/PUTOccupation404ErrorSchema'
+   *       '415':
+   *         description: |
+   *           The request is not supported because the media type is not acceptable.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/AllContentType415ResponseSchema'
+   *       '500':
+   *         description: |
+   *           The server encountered an unexpected condition.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/All500ResponseSchema'
+   *
+   */
+  @RoleRequired(AuthAPISpecs.Enums.TabiyaRoles.MODEL_MANAGER)
+  async put(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+    const parsedRequestResult = parseAndValidatePUTRequest(event);
+    if ("statusCode" in parsedRequestResult) {
+      return parsedRequestResult;
+    }
+    const payload = parsedRequestResult;
+
+    const params = extractAndValidateIdParams(event, Routes.OCCUPATION_ROUTE);
+    if ("statusCode" in params) {
+      return params;
+    }
+
+    if (payload.modelId !== params.modelId) {
+      return errorResponse(
+        StatusCodes.BAD_REQUEST,
+        OccupationAPISpecs.Occupation.PUT.Errors.Status400.ErrorCodes.INVALID_MODEL_ID,
+        "modelId in payload does not match modelId in path",
+        `Payload modelId: ${payload.modelId}, Path modelId: ${params.modelId}`
+      );
+    }
+
+    const spec: IUpdateOccupationSpec = {
+      originUri: payload.originUri,
+      code: payload.code,
+      description: payload.description,
+      preferredLabel: payload.preferredLabel,
+      altLabels: payload.altLabels,
+      occupationType:
+        payload.occupationType === OccupationAPISpecs.Enums.OccupationType.ESCOOccupation
+          ? ObjectTypes.ESCOOccupation
+          : ObjectTypes.LocalOccupation,
+      modelId: payload.modelId,
+      UUIDHistory: payload.UUIDHistory,
+      occupationGroupCode: payload.occupationGroupCode,
+      definition: payload.definition,
+      scopeNote: payload.scopeNote,
+      regulatedProfessionNote: payload.regulatedProfessionNote,
+      isLocalized: payload.isLocalized,
+    };
+
+    try {
+      const service = getServiceRegistry().occupation;
+      const updatedOccupation = await service.update(params.id, params.modelId, spec);
+      if (!updatedOccupation) {
+        return errorResponse(
+          StatusCodes.NOT_FOUND,
+          OccupationAPISpecs.Occupation.PUT.Errors.Status404.ErrorCodes.OCCUPATION_NOT_FOUND,
+          "Occupation not found",
+          `No occupation found with id: ${params.id}`
+        );
+      }
+      return responseJSON(StatusCodes.OK, buildPUTResponse(updatedOccupation, getResourcesBaseUrl()));
+    } catch (error: unknown) {
+      console.error("Failed to update occupation:", error);
+
+      if (error instanceof OccupationModelValidationError) {
+        switch (error.code) {
+          case ModelForOccupationValidationErrorCode.MODEL_NOT_FOUND_BY_ID:
+            return errorResponse(
+              StatusCodes.NOT_FOUND,
+              OccupationAPISpecs.Occupation.PUT.Errors.Status404.ErrorCodes.MODEL_NOT_FOUND,
+              "Model not found by the provided ID",
+              ""
+            );
+          case ModelForOccupationValidationErrorCode.MODEL_IS_RELEASED:
+            return errorResponse(
+              StatusCodes.BAD_REQUEST,
+              OccupationAPISpecs.Occupation.PUT.Errors.Status400.ErrorCodes.UNABLE_TO_ALTER_RELEASED_MODEL,
+              "Cannot update occupations in a released model",
+              ""
+            );
+          case ModelForOccupationValidationErrorCode.FAILED_TO_FETCH_FROM_DB:
+            return errorResponse(
+              StatusCodes.INTERNAL_SERVER_ERROR,
+              OccupationAPISpecs.Occupation.PUT.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION,
+              "Failed to fetch the model details from the DB",
+              ""
+            );
+          default:
+            return errorResponse(
+              StatusCodes.INTERNAL_SERVER_ERROR,
+              OccupationAPISpecs.Occupation.PUT.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION,
+              "Failed to update the occupation in the DB",
+              ""
+            );
+        }
+      } else {
+        return errorResponse(
+          StatusCodes.INTERNAL_SERVER_ERROR,
+          OccupationAPISpecs.Occupation.PUT.Errors.Status500.ErrorCodes.DB_FAILED_TO_UPDATE_OCCUPATION,
+          "Failed to update the occupation in the DB",
+          ""
+        );
+      }
+    }
+  }
+}
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  return new OccupationPUTController().put(event);
+};

--- a/backend/src/esco/occupations/[id]/PUT/request.ts
+++ b/backend/src/esco/occupations/[id]/PUT/request.ts
@@ -1,0 +1,43 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { STD_ERRORS_RESPONSES } from "server/httpUtils";
+import { ajvInstance, ParseValidationError } from "validator";
+import { ValidateFunction } from "ajv";
+import OccupationAPISpecs from "api-specifications/esco/occupation";
+
+export function parseAndValidatePUTRequest(
+  event: APIGatewayProxyEvent
+): OccupationAPISpecs.Occupation.PUT.Types.Request.Payload | APIGatewayProxyResult {
+  if (!event.headers?.["Content-Type"]?.includes("application/json")) {
+    return STD_ERRORS_RESPONSES.UNSUPPORTED_MEDIA_TYPE_ERROR;
+  }
+
+  if (event.body == null) {
+    return STD_ERRORS_RESPONSES.MALFORMED_BODY_ERROR("Body is empty");
+  }
+
+  if (event.body.length > OccupationAPISpecs.Occupation.PUT.Constants.MAX_PUT_PAYLOAD_LENGTH) {
+    return STD_ERRORS_RESPONSES.TOO_LARGE_PAYLOAD_ERROR(
+      `Expected maximum length is ${OccupationAPISpecs.Occupation.PUT.Constants.MAX_PUT_PAYLOAD_LENGTH}`
+    );
+  }
+
+  let payload: OccupationAPISpecs.Occupation.PUT.Types.Request.Payload;
+  try {
+    payload = JSON.parse(event.body);
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    return STD_ERRORS_RESPONSES.MALFORMED_BODY_ERROR(errorMessage);
+  }
+
+  const validateFunction = ajvInstance.getSchema(
+    OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload.$id as string
+  ) as ValidateFunction;
+
+  const isValid = validateFunction(payload);
+  if (!isValid) {
+    const errorDetail = ParseValidationError(validateFunction.errors);
+    return STD_ERRORS_RESPONSES.INVALID_JSON_SCHEMA_ERROR(errorDetail);
+  }
+
+  return payload;
+}

--- a/backend/src/esco/occupations/[id]/PUT/response.ts
+++ b/backend/src/esco/occupations/[id]/PUT/response.ts
@@ -1,0 +1,6 @@
+import { transform } from "../../_shared/transform";
+import { IOccupation } from "../../_shared/occupation.types";
+
+export function buildPUTResponse(occupation: IOccupation, baseURL: string) {
+  return transform(occupation, baseURL);
+}

--- a/backend/src/esco/occupations/_shared/occupation.types.ts
+++ b/backend/src/esco/occupations/_shared/occupation.types.ts
@@ -76,3 +76,30 @@ export type INewOccupationSpecWithoutImportId = Omit<INewOccupationSpec, "import
 export interface IOccupationWithoutImportId extends Omit<IOccupation, "importId"> {
   importId: string | null;
 }
+
+/**
+ * Describes the mutable fields for a full occupation replacement (PUT).
+ * Excludes server-managed fields: id, UUID, importId, parent, children, requiresSkills, createdAt, updatedAt.
+ */
+export type IUpdateOccupationSpec = Pick<
+  IOccupation,
+  | "code"
+  | "occupationGroupCode"
+  | "preferredLabel"
+  | "originUri"
+  | "altLabels"
+  | "definition"
+  | "description"
+  | "regulatedProfessionNote"
+  | "scopeNote"
+  | "modelId"
+  | "occupationType"
+  | "UUIDHistory"
+  | "isLocalized"
+>;
+
+/**
+ * Describes the mutable fields for a partial occupation update (PATCH).
+ * All fields are optional.
+ */
+export type IPartialUpdateOccupationSpec = Partial<IUpdateOccupationSpec>;

--- a/backend/src/esco/occupations/index.test.ts
+++ b/backend/src/esco/occupations/index.test.ts
@@ -145,4 +145,16 @@ describe("Occupations Router", () => {
     const response = await handler(event);
     expect(response).toEqual(STD_ERRORS_RESPONSES.METHOD_NOT_ALLOWED);
   });
+
+  test("should handle missing path in PUT request", async () => {
+    const event = { httpMethod: HTTP_VERBS.PUT } as unknown as APIGatewayProxyEvent;
+    const response = await handler(event);
+    expect(response).toEqual(STD_ERRORS_RESPONSES.METHOD_NOT_ALLOWED);
+  });
+
+  test("should handle missing path in PATCH request", async () => {
+    const event = { httpMethod: HTTP_VERBS.PATCH } as unknown as APIGatewayProxyEvent;
+    const response = await handler(event);
+    expect(response).toEqual(STD_ERRORS_RESPONSES.METHOD_NOT_ALLOWED);
+  });
 });

--- a/backend/src/esco/occupations/index.test.ts
+++ b/backend/src/esco/occupations/index.test.ts
@@ -21,8 +21,11 @@ jest.mock("./[id]/skills/GET/index", () => ({
 jest.mock("./[id]/skills/POST/index", () => ({
   handler: jest.fn().mockResolvedValue({ statusCode: 201, body: "POST_SKILLS" }),
 }));
-jest.mock("./[id]/history/GET/index", () => ({
-  handler: jest.fn().mockResolvedValue({ statusCode: 200, body: "GET_HISTORY" }),
+jest.mock("./[id]/PUT/index", () => ({
+  handler: jest.fn().mockResolvedValue({ statusCode: 200, body: "PUT" }),
+}));
+jest.mock("./[id]/PATCH/index", () => ({
+  handler: jest.fn().mockResolvedValue({ statusCode: 200, body: "PATCH" }),
 }));
 
 import { handler as getHandler } from "./GET/index";
@@ -33,7 +36,8 @@ import { handler as postParentHandler } from "./[id]/parent/POST/index";
 import { handler as getChildrenHandler } from "./[id]/children/GET/index";
 import { handler as getSkillsHandler } from "./[id]/skills/GET/index";
 import { handler as postSkillsHandler } from "./[id]/skills/POST/index";
-import { handler as getHistoryHandler } from "./[id]/history/GET/index";
+import { handler as putByIdHandler } from "./[id]/PUT/index";
+import { handler as patchByIdHandler } from "./[id]/PATCH/index";
 
 describe("Occupations Router", () => {
   beforeEach(() => {
@@ -96,13 +100,6 @@ describe("Occupations Router", () => {
     expect(response.body).toBe("GET_SKILLS");
   });
 
-  test("should route GET history to getHistoryHandler", async () => {
-    const event = { httpMethod: HTTP_VERBS.GET, path: "/models/1/occupations/2/history" } as APIGatewayProxyEvent;
-    const response = await handler(event);
-    expect(getHistoryHandler).toHaveBeenCalledWith(event);
-    expect(response.body).toBe("GET_HISTORY");
-  });
-
   test("should return METHOD_NOT_ALLOWED for unsupported verbs", async () => {
     const event = { httpMethod: HTTP_VERBS.DELETE } as APIGatewayProxyEvent;
     const response = await handler(event);
@@ -121,5 +118,31 @@ describe("Occupations Router", () => {
     const response = await handler(event);
     expect(postHandler).toHaveBeenCalledWith(event);
     expect(response.body).toBe("POST");
+  });
+
+  test("should route PUT to putByIdHandler", async () => {
+    const event = { httpMethod: HTTP_VERBS.PUT, path: "/models/1/occupations/2" } as APIGatewayProxyEvent;
+    const response = await handler(event);
+    expect(putByIdHandler).toHaveBeenCalledWith(event);
+    expect(response.body).toBe("PUT");
+  });
+
+  test("should route PATCH to patchByIdHandler", async () => {
+    const event = { httpMethod: HTTP_VERBS.PATCH, path: "/models/1/occupations/2" } as APIGatewayProxyEvent;
+    const response = await handler(event);
+    expect(patchByIdHandler).toHaveBeenCalledWith(event);
+    expect(response.body).toBe("PATCH");
+  });
+
+  test("should return METHOD_NOT_ALLOWED for PUT without matching path", async () => {
+    const event = { httpMethod: HTTP_VERBS.PUT, path: "/invalid/path" } as APIGatewayProxyEvent;
+    const response = await handler(event);
+    expect(response).toEqual(STD_ERRORS_RESPONSES.METHOD_NOT_ALLOWED);
+  });
+
+  test("should return METHOD_NOT_ALLOWED for PATCH without matching path", async () => {
+    const event = { httpMethod: HTTP_VERBS.PATCH, path: "/invalid/path" } as APIGatewayProxyEvent;
+    const response = await handler(event);
+    expect(response).toEqual(STD_ERRORS_RESPONSES.METHOD_NOT_ALLOWED);
   });
 });

--- a/backend/src/esco/occupations/index.ts
+++ b/backend/src/esco/occupations/index.ts
@@ -12,7 +12,8 @@ import { handler as postParentHandler } from "./[id]/parent/POST/index";
 import { handler as getChildrenHandler } from "./[id]/children/GET/index";
 import { handler as getSkillsHandler } from "./[id]/skills/GET/index";
 import { handler as postSkillsHandler } from "./[id]/skills/POST/index";
-import { handler as getHistoryHandler } from "./[id]/history/GET/index";
+import { handler as putByIdHandler } from "./[id]/PUT/index";
+import { handler as patchByIdHandler } from "./[id]/PATCH/index";
 
 export const handler: (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult> = async (
   event: APIGatewayProxyEvent
@@ -34,12 +35,20 @@ export const handler: (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyRe
       return getChildrenHandler(event);
     } else if (pathToRegexp(Routes.OCCUPATION_SKILLS_ROUTE).regexp.exec(pathToMatch)) {
       return getSkillsHandler(event);
-    } else if (pathToRegexp(Routes.OCCUPATION_HISTORY_ROUTE).regexp.exec(pathToMatch)) {
-      return getHistoryHandler(event);
     } else if (pathToRegexp(Routes.OCCUPATION_ROUTE).regexp.exec(pathToMatch)) {
       return getByIdHandler(event);
     } else {
       return getHandler(event);
+    }
+  } else if (event?.httpMethod === HTTP_VERBS.PUT) {
+    const pathToMatch = event.path || "";
+    if (pathToRegexp(Routes.OCCUPATION_ROUTE).regexp.exec(pathToMatch)) {
+      return putByIdHandler(event);
+    }
+  } else if (event?.httpMethod === HTTP_VERBS.PATCH) {
+    const pathToMatch = event.path || "";
+    if (pathToRegexp(Routes.OCCUPATION_ROUTE).regexp.exec(pathToMatch)) {
+      return patchByIdHandler(event);
     }
   }
   return STD_ERRORS_RESPONSES.METHOD_NOT_ALLOWED;

--- a/backend/src/esco/occupations/repository/occupation.repository.test.ts
+++ b/backend/src/esco/occupations/repository/occupation.repository.test.ts
@@ -10,7 +10,13 @@ import { initOnce } from "server/init";
 import { getConnectionManager } from "server/connection/connectionManager";
 import { IOccupationRepository, SearchFilter } from "./occupation.repository";
 import { getTestConfiguration } from "_test_utilities/getTestConfiguration";
-import { INewOccupationSpec, IOccupation, IOccupationDoc } from "../_shared/occupation.types";
+import {
+  INewOccupationSpec,
+  IOccupation,
+  IOccupationDoc,
+  IPartialUpdateOccupationSpec,
+  IUpdateOccupationSpec,
+} from "../_shared/occupation.types";
 import { INewSkillSpec, ISkillReference, ReuseLevel, SkillType } from "esco/skill/_shared/skill.types";
 import { ObjectTypes, SignallingValueLabel } from "esco/common/objectTypes";
 import {
@@ -2327,6 +2333,181 @@ describe("Test the Occupation Repository with an in-memory mongodb", () => {
       );
 
       aggregateSpy.mockRestore();
+    });
+  });
+
+  describe("update", () => {
+    test("should successfully update an occupation", async () => {
+      // GIVEN an occupation exists in the database
+      const modelId = getMockStringId(1);
+      const givenSpec = getSimpleNewESCOOccupationSpec(modelId, "occ_to_update");
+      const occupation = await repository.create(givenSpec);
+
+      // WHEN updating the occupation
+      const newSpec = getNewESCOOccupationSpec();
+      const updateSpec: IUpdateOccupationSpec = {
+        modelId,
+        preferredLabel: newSpec.preferredLabel,
+        code: newSpec.code,
+        altLabels: newSpec.altLabels,
+        description: newSpec.description,
+        definition: newSpec.definition,
+        scopeNote: newSpec.scopeNote,
+        regulatedProfessionNote: newSpec.regulatedProfessionNote,
+        occupationType: ObjectTypes.ESCOOccupation,
+        isLocalized: false,
+        originUri: newSpec.originUri,
+        occupationGroupCode: newSpec.occupationGroupCode,
+        UUIDHistory: newSpec.UUIDHistory,
+      };
+      const actual = await repository.update(occupation.id, updateSpec);
+
+      // THEN expect it to be updated
+      expect(actual).not.toBeNull();
+      expect(actual?.preferredLabel).toEqual(updateSpec.preferredLabel);
+      expect(actual?.code).toEqual(updateSpec.code);
+      expect(actual?.altLabels).toEqual(updateSpec.altLabels);
+      expect(actual?.description).toEqual(updateSpec.description);
+      expect(actual?.definition).toEqual(updateSpec.definition);
+      expect(actual?.scopeNote).toEqual(updateSpec.scopeNote);
+      expect(actual?.regulatedProfessionNote).toEqual(updateSpec.regulatedProfessionNote);
+      expect(actual?.originUri).toEqual(updateSpec.originUri);
+      expect(actual?.occupationGroupCode).toEqual(updateSpec.occupationGroupCode);
+      expect(actual?.UUIDHistory).toEqual(updateSpec.UUIDHistory);
+    });
+
+    test("should return null if occupation does not exist", async () => {
+      // GIVEN a non-existent occupation ID
+      const nonExistentId = getMockStringId(2);
+      const newSpec = getNewESCOOccupationSpec();
+      const updateSpec: IUpdateOccupationSpec = {
+        modelId: getMockStringId(1),
+        preferredLabel: newSpec.preferredLabel,
+        code: newSpec.code,
+        altLabels: newSpec.altLabels,
+        description: newSpec.description,
+        definition: newSpec.definition,
+        scopeNote: newSpec.scopeNote,
+        regulatedProfessionNote: newSpec.regulatedProfessionNote,
+        occupationType: ObjectTypes.ESCOOccupation,
+        isLocalized: false,
+        originUri: newSpec.originUri,
+        occupationGroupCode: newSpec.occupationGroupCode,
+        UUIDHistory: newSpec.UUIDHistory,
+      };
+
+      // WHEN updating
+      const actual = await repository.update(nonExistentId, updateSpec);
+
+      // THEN expect null
+      expect(actual).toBeNull();
+    });
+
+    test("should return null if invalid ID is provided", async () => {
+      // WHEN updating with invalid ID
+      const actual = await repository.update("invalid-id", {} as IUpdateOccupationSpec);
+      // THEN expect null
+      expect(actual).toBeNull();
+    });
+
+    test("should throw if save fails during update", async () => {
+      // GIVEN a valid ID and spec
+      const modelId = getMockStringId(1);
+      const updateSpec: IUpdateOccupationSpec = {
+        modelId,
+        preferredLabel: "new label",
+        code: "1234.5.6",
+        altLabels: [],
+        description: "new desc",
+        definition: "new def",
+        scopeNote: "new scope",
+        regulatedProfessionNote: "new note",
+        occupationType: ObjectTypes.ESCOOccupation,
+        isLocalized: false,
+        originUri: "http://example.com",
+        occupationGroupCode: "1234",
+        UUIDHistory: [],
+      };
+
+      // AND findById returns a mock doc whose save will fail
+      const mockDoc = {
+        set: jest.fn(),
+        save: jest.fn().mockRejectedValue(new Error("Save failed")),
+        populate: jest.fn().mockResolvedValue(undefined),
+        toObject: jest.fn(),
+      };
+      jest.spyOn(repository.Model, "findById").mockResolvedValueOnce(mockDoc as any);
+
+      // WHEN updating
+      // THEN expect an error
+      await expect(repository.update(new mongoose.Types.ObjectId().toHexString(), updateSpec)).rejects.toThrow(
+        "OccupationRepository.update: update failed."
+      );
+    });
+  });
+
+  describe("patch", () => {
+    test("should successfully patch an occupation", async () => {
+      // GIVEN an occupation exists in the database
+      const modelId = getMockStringId(1);
+      const givenSpec = getSimpleNewESCOOccupationSpec(modelId, "occ_to_patch");
+      const occupation = await repository.create(givenSpec);
+
+      // WHEN patching the occupation
+      const patchSpec: IPartialUpdateOccupationSpec = {
+        preferredLabel: "patched label",
+        description: "patched desc",
+      };
+      const actual = await repository.patch(occupation.id, patchSpec);
+
+      // THEN expect it to be patched
+      expect(actual).not.toBeNull();
+      expect(actual?.preferredLabel).toEqual(patchSpec.preferredLabel);
+      expect(actual?.description).toEqual(patchSpec.description);
+      expect(actual?.code).toEqual(occupation.code); // Unchanged
+    });
+
+    test("should return null if occupation does not exist", async () => {
+      // GIVEN a non-existent occupation ID
+      const nonExistentId = getMockStringId(2);
+      const patchSpec: IPartialUpdateOccupationSpec = {
+        preferredLabel: "patched label",
+      };
+
+      // WHEN patching
+      const actual = await repository.patch(nonExistentId, patchSpec);
+
+      // THEN expect null
+      expect(actual).toBeNull();
+    });
+
+    test("should return null if invalid ID is provided", async () => {
+      // WHEN patching with invalid ID
+      const actual = await repository.patch("invalid-id", {} as IPartialUpdateOccupationSpec);
+      // THEN expect null
+      expect(actual).toBeNull();
+    });
+
+    test("should throw if save fails during patch", async () => {
+      // GIVEN a valid ID and spec
+      const patchSpec: IPartialUpdateOccupationSpec = {
+        preferredLabel: "patched label",
+      };
+
+      // AND findById returns a mock doc whose save will fail
+      const mockDoc = {
+        set: jest.fn(),
+        save: jest.fn().mockRejectedValue(new Error("Save failed")),
+        populate: jest.fn().mockResolvedValue(undefined),
+        toObject: jest.fn(),
+      };
+      jest.spyOn(repository.Model, "findById").mockResolvedValueOnce(mockDoc as any);
+
+      // WHEN patching
+      // THEN expect an error
+      await expect(repository.patch(new mongoose.Types.ObjectId().toHexString(), patchSpec)).rejects.toThrow(
+        "OccupationRepository.patch: patch failed."
+      );
     });
   });
 });

--- a/backend/src/esco/occupations/repository/occupation.repository.test.ts
+++ b/backend/src/esco/occupations/repository/occupation.repository.test.ts
@@ -2360,7 +2360,7 @@ describe("Test the Occupation Repository with an in-memory mongodb", () => {
         occupationGroupCode: newSpec.occupationGroupCode,
         UUIDHistory: newSpec.UUIDHistory,
       };
-      const actual = await repository.update(occupation.id, updateSpec);
+      const actual = await repository.update(occupation.id, modelId, updateSpec);
 
       // THEN expect it to be updated
       expect(actual).not.toBeNull();
@@ -2397,7 +2397,7 @@ describe("Test the Occupation Repository with an in-memory mongodb", () => {
       };
 
       // WHEN updating
-      const actual = await repository.update(nonExistentId, updateSpec);
+      const actual = await repository.update(nonExistentId, getMockStringId(1), updateSpec);
 
       // THEN expect null
       expect(actual).toBeNull();
@@ -2405,7 +2405,7 @@ describe("Test the Occupation Repository with an in-memory mongodb", () => {
 
     test("should return null if invalid ID is provided", async () => {
       // WHEN updating with invalid ID
-      const actual = await repository.update("invalid-id", {} as IUpdateOccupationSpec);
+      const actual = await repository.update("invalid-id", getMockStringId(1), {} as IUpdateOccupationSpec);
       // THEN expect null
       expect(actual).toBeNull();
     });
@@ -2436,11 +2436,11 @@ describe("Test the Occupation Repository with an in-memory mongodb", () => {
         populate: jest.fn().mockResolvedValue(undefined),
         toObject: jest.fn(),
       };
-      jest.spyOn(repository.Model, "findById").mockResolvedValueOnce(mockDoc as unknown as IOccupationDoc);
+      jest.spyOn(repository.Model, "findOne").mockResolvedValueOnce(mockDoc as unknown as IOccupationDoc);
 
       // WHEN updating
       // THEN expect an error
-      await expect(repository.update(new mongoose.Types.ObjectId().toHexString(), updateSpec)).rejects.toThrow(
+      await expect(repository.update(new mongoose.Types.ObjectId().toHexString(), modelId, updateSpec)).rejects.toThrow(
         "OccupationRepository.update: update failed."
       );
     });
@@ -2458,7 +2458,7 @@ describe("Test the Occupation Repository with an in-memory mongodb", () => {
         preferredLabel: "patched label",
         description: "patched desc",
       };
-      const actual = await repository.patch(occupation.id, patchSpec);
+      const actual = await repository.patch(occupation.id, modelId, patchSpec);
 
       // THEN expect it to be patched
       expect(actual).not.toBeNull();
@@ -2475,7 +2475,7 @@ describe("Test the Occupation Repository with an in-memory mongodb", () => {
       };
 
       // WHEN patching
-      const actual = await repository.patch(nonExistentId, patchSpec);
+      const actual = await repository.patch(nonExistentId, getMockStringId(1), patchSpec);
 
       // THEN expect null
       expect(actual).toBeNull();
@@ -2483,7 +2483,7 @@ describe("Test the Occupation Repository with an in-memory mongodb", () => {
 
     test("should return null if invalid ID is provided", async () => {
       // WHEN patching with invalid ID
-      const actual = await repository.patch("invalid-id", {} as IPartialUpdateOccupationSpec);
+      const actual = await repository.patch("invalid-id", getMockStringId(1), {} as IPartialUpdateOccupationSpec);
       // THEN expect null
       expect(actual).toBeNull();
     });
@@ -2501,13 +2501,13 @@ describe("Test the Occupation Repository with an in-memory mongodb", () => {
         populate: jest.fn().mockResolvedValue(undefined),
         toObject: jest.fn(),
       };
-      jest.spyOn(repository.Model, "findById").mockResolvedValueOnce(mockDoc as unknown as IOccupationDoc);
+      jest.spyOn(repository.Model, "findOne").mockResolvedValueOnce(mockDoc as unknown as IOccupationDoc);
 
       // WHEN patching
       // THEN expect an error
-      await expect(repository.patch(new mongoose.Types.ObjectId().toHexString(), patchSpec)).rejects.toThrow(
-        "OccupationRepository.patch: patch failed."
-      );
+      await expect(
+        repository.patch(new mongoose.Types.ObjectId().toHexString(), getMockStringId(1), patchSpec)
+      ).rejects.toThrow("OccupationRepository.patch: patch failed.");
     });
   });
 });

--- a/backend/src/esco/occupations/repository/occupation.repository.test.ts
+++ b/backend/src/esco/occupations/repository/occupation.repository.test.ts
@@ -2436,7 +2436,7 @@ describe("Test the Occupation Repository with an in-memory mongodb", () => {
         populate: jest.fn().mockResolvedValue(undefined),
         toObject: jest.fn(),
       };
-      jest.spyOn(repository.Model, "findById").mockResolvedValueOnce(mockDoc as any);
+      jest.spyOn(repository.Model, "findById").mockResolvedValueOnce(mockDoc as unknown as IOccupationDoc);
 
       // WHEN updating
       // THEN expect an error
@@ -2501,7 +2501,7 @@ describe("Test the Occupation Repository with an in-memory mongodb", () => {
         populate: jest.fn().mockResolvedValue(undefined),
         toObject: jest.fn(),
       };
-      jest.spyOn(repository.Model, "findById").mockResolvedValueOnce(mockDoc as any);
+      jest.spyOn(repository.Model, "findById").mockResolvedValueOnce(mockDoc as unknown as IOccupationDoc);
 
       // WHEN patching
       // THEN expect an error

--- a/backend/src/esco/occupations/repository/occupation.repository.ts
+++ b/backend/src/esco/occupations/repository/occupation.repository.ts
@@ -5,7 +5,9 @@ import {
   INewOccupationSpecWithoutImportId,
   IOccupation,
   IOccupationDoc,
+  IPartialUpdateOccupationSpec,
   ISkillWithRelation,
+  IUpdateOccupationSpec,
 } from "../_shared/occupation.types";
 import { IOccupationGroup } from "esco/occupationGroup/_shared/OccupationGroup.types";
 import {
@@ -158,6 +160,26 @@ export interface IOccupationRepository {
     limit: number,
     cursor?: string
   ): Promise<ISkillWithRelation[]>;
+
+  /**
+   * Fully replaces the mutable fields of an Occupation (PUT semantics).
+   *
+   * @param {string} id - The ID of the Occupation to update.
+   * @param {IUpdateOccupationSpec} spec - The full set of new field values.
+   * @return {Promise<IOccupation | null>} - The updated occupation, or null if not found.
+   * Rejects with an error if the operation fails.
+   */
+  update(id: string, spec: IUpdateOccupationSpec): Promise<IOccupation | null>;
+
+  /**
+   * Partially updates an Occupation (PATCH semantics).
+   *
+   * @param {string} id - The ID of the Occupation to update.
+   * @param {IPartialUpdateOccupationSpec} spec - Only the fields to update.
+   * @return {Promise<IOccupation | null>} - The updated occupation, or null if not found.
+   * Rejects with an error if the operation fails.
+   */
+  patch(id: string, spec: IPartialUpdateOccupationSpec): Promise<IOccupation | null>;
 }
 
 export class OccupationRepository implements IOccupationRepository {
@@ -629,6 +651,44 @@ export class OccupationRepository implements IOccupationRepository {
       const err = new Error("OccupationRepository.findSkillsForOccupation: findSkillsForOccupation failed", {
         cause: e,
       });
+      throw err;
+    }
+  }
+
+  async update(id: string, spec: IUpdateOccupationSpec): Promise<IOccupation | null> {
+    try {
+      if (!mongoose.Types.ObjectId.isValid(id)) return null;
+      const doc = await this.Model.findById(id).exec();
+      if (!doc) return null;
+      doc.set(spec);
+      await doc.save();
+      await doc.populate([
+        populateOccupationParentOptions,
+        populateOccupationChildrenOptions,
+        populateOccupationRequiresSkillsOptions,
+      ]);
+      return doc.toObject();
+    } catch (e: unknown) {
+      const err = new Error("OccupationRepository.update: update failed.", { cause: e });
+      throw err;
+    }
+  }
+
+  async patch(id: string, spec: IPartialUpdateOccupationSpec): Promise<IOccupation | null> {
+    try {
+      if (!mongoose.Types.ObjectId.isValid(id)) return null;
+      const doc = await this.Model.findById(id).exec();
+      if (!doc) return null;
+      doc.set(spec);
+      await doc.save();
+      await doc.populate([
+        populateOccupationParentOptions,
+        populateOccupationChildrenOptions,
+        populateOccupationRequiresSkillsOptions,
+      ]);
+      return doc.toObject();
+    } catch (e: unknown) {
+      const err = new Error("OccupationRepository.patch: patch failed.", { cause: e });
       throw err;
     }
   }

--- a/backend/src/esco/occupations/repository/occupation.repository.ts
+++ b/backend/src/esco/occupations/repository/occupation.repository.ts
@@ -165,21 +165,23 @@ export interface IOccupationRepository {
    * Fully replaces the mutable fields of an Occupation (PUT semantics).
    *
    * @param {string} id - The ID of the Occupation to update.
+   * @param {string} modelId - The model ID the Occupation belongs to.
    * @param {IUpdateOccupationSpec} spec - The full set of new field values.
    * @return {Promise<IOccupation | null>} - The updated occupation, or null if not found.
    * Rejects with an error if the operation fails.
    */
-  update(id: string, spec: IUpdateOccupationSpec): Promise<IOccupation | null>;
+  update(id: string, modelId: string, spec: IUpdateOccupationSpec): Promise<IOccupation | null>;
 
   /**
    * Partially updates an Occupation (PATCH semantics).
    *
    * @param {string} id - The ID of the Occupation to update.
+   * @param {string} modelId - The model ID the Occupation belongs to.
    * @param {IPartialUpdateOccupationSpec} spec - Only the fields to update.
    * @return {Promise<IOccupation | null>} - The updated occupation, or null if not found.
    * Rejects with an error if the operation fails.
    */
-  patch(id: string, spec: IPartialUpdateOccupationSpec): Promise<IOccupation | null>;
+  patch(id: string, modelId: string, spec: IPartialUpdateOccupationSpec): Promise<IOccupation | null>;
 }
 
 export class OccupationRepository implements IOccupationRepository {
@@ -655,10 +657,10 @@ export class OccupationRepository implements IOccupationRepository {
     }
   }
 
-  async update(id: string, spec: IUpdateOccupationSpec): Promise<IOccupation | null> {
+  async update(id: string, modelId: string, spec: IUpdateOccupationSpec): Promise<IOccupation | null> {
     try {
       if (!mongoose.Types.ObjectId.isValid(id)) return null;
-      const doc = await this.Model.findById(id).exec();
+      const doc = await this.Model.findOne({ _id: id, modelId: modelId }).exec();
       if (!doc) return null;
       doc.set(spec);
       await doc.save();
@@ -674,10 +676,10 @@ export class OccupationRepository implements IOccupationRepository {
     }
   }
 
-  async patch(id: string, spec: IPartialUpdateOccupationSpec): Promise<IOccupation | null> {
+  async patch(id: string, modelId: string, spec: IPartialUpdateOccupationSpec): Promise<IOccupation | null> {
     try {
       if (!mongoose.Types.ObjectId.isValid(id)) return null;
-      const doc = await this.Model.findById(id).exec();
+      const doc = await this.Model.findOne({ _id: id, modelId: modelId }).exec();
       if (!doc) return null;
       doc.set(spec);
       await doc.save();

--- a/backend/src/esco/occupations/services/occupation.service.test.ts
+++ b/backend/src/esco/occupations/services/occupation.service.test.ts
@@ -700,7 +700,7 @@ describe("Test the OccupationService", () => {
       const actual = await service.update(givenId, givenSpec.modelId, givenSpec);
 
       // THEN expect repository.update to be called with the spec
-      expect(mockRepository.update).toHaveBeenCalledWith(givenId, givenSpec);
+      expect(mockRepository.update).toHaveBeenCalledWith(givenId, givenSpec.modelId, givenSpec);
       // AND expect the returned occupation
       expect(actual).toEqual(givenUpdatedOccupation);
     });
@@ -823,7 +823,7 @@ describe("Test the OccupationService", () => {
       const actual = await service.patch(givenId, givenModelId, givenSpec);
 
       // THEN expect repository.patch to be called with the spec
-      expect(mockRepository.patch).toHaveBeenCalledWith(givenId, givenSpec);
+      expect(mockRepository.patch).toHaveBeenCalledWith(givenId, givenModelId, givenSpec);
       // AND expect the returned occupation
       expect(actual).toEqual(givenUpdatedOccupation);
     });

--- a/backend/src/esco/occupations/services/occupation.service.test.ts
+++ b/backend/src/esco/occupations/services/occupation.service.test.ts
@@ -4,16 +4,18 @@ import {
   ModelForOccupationValidationErrorCode,
   OccupationModelValidationError,
 } from "./occupation.service.types";
-import { INewOccupationSpecWithoutImportId, IOccupation } from "../_shared/occupation.types";
-import { IOccupationReference } from "../_shared/occupationReference.types";
+import {
+  INewOccupationSpecWithoutImportId,
+  IOccupation,
+  IPartialUpdateOccupationSpec,
+  IUpdateOccupationSpec,
+} from "../_shared/occupation.types";
 import { IOccupationRepository } from "../repository/occupation.repository";
 import { getMockStringId } from "_test_utilities/mockMongoId";
 import { getRandomString } from "_test_utilities/getMockRandomData";
 import { ObjectTypes } from "esco/common/objectTypes";
 import { IModelRepository } from "modelInfo/modelInfoRepository";
 import { IModelInfo } from "modelInfo/modelInfo.types";
-import { getIModelInfoMockData } from "modelInfo/testDataHelper";
-import { randomUUID } from "crypto";
 import mongoose from "mongoose";
 
 // Mock the module at the top level
@@ -34,16 +36,15 @@ describe("Test the OccupationService", () => {
       findAll: jest.fn(),
       findPaginated: jest.fn(),
       getOccupationByUUID: jest.fn(),
-      findHistoryReferencesByUUIDs: jest.fn(),
       findParent: jest.fn(),
       findChildren: jest.fn(),
       findSkillsForOccupation: jest.fn(),
+      update: jest.fn(),
+      patch: jest.fn(),
     } as unknown as jest.Mocked<IOccupationRepository>;
 
     mockModelRepository = {
       getModelById: jest.fn(),
-      getModelsByIds: jest.fn(),
-      getHistory: jest.fn(),
     } as unknown as jest.Mocked<IModelRepository>;
 
     service = new OccupationService(mockRepository, mockModelRepository);
@@ -653,143 +654,252 @@ describe("Test the OccupationService", () => {
     });
   });
 
-  describe("getHistory", () => {
-    // An occupation's UUIDHistory holds its OWN past UUIDs; the service resolves each to the occupation's
-    // reference (as it was in that model) + its modelId, then fetches that model and strips it to a reference.
-    function givenModelWithId(n: number, modelId: string): IModelInfo {
-      return { ...getIModelInfoMockData(n), id: modelId };
-    }
+  describe("update", () => {
+    const buildSpec = (): IUpdateOccupationSpec => ({
+      modelId: getMockStringId(1),
+      preferredLabel: getRandomString(10),
+      code: getRandomString(5),
+      altLabels: [getRandomString(5)],
+      description: getRandomString(20),
+      definition: getRandomString(20),
+      scopeNote: getRandomString(20),
+      regulatedProfessionNote: getRandomString(20),
+      occupationType: ObjectTypes.ESCOOccupation,
+      isLocalized: false,
+      originUri: getRandomString(10),
+      occupationGroupCode: getRandomString(5),
+      UUIDHistory: [],
+    });
 
-    function givenReference(uuid: string): IOccupationReference {
-      return {
-        id: getMockStringId(Math.floor(Math.random() * 100000)),
-        UUID: uuid,
-        preferredLabel: getRandomString(10),
-        occupationGroupCode: getRandomString(5),
+    test("should call repository.update with the given spec when model validation passes", async () => {
+      // GIVEN a full update spec
+      const givenId = getMockStringId(2);
+      const givenSpec = buildSpec();
+
+      // AND the model is not released
+      mockModelRepository.getModelById.mockResolvedValue({
+        id: givenSpec.modelId,
+        released: false,
+      } as unknown as IModelInfo);
+
+      // AND the repository returns the updated occupation
+      const givenUpdatedOccupation: IOccupation = {
+        ...givenSpec,
+        id: givenId,
+        UUID: getRandomString(10),
+        parent: null,
+        children: [],
+        requiresSkills: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        importId: "",
+      };
+      mockRepository.update = jest.fn().mockResolvedValue(givenUpdatedOccupation);
+
+      // WHEN calling service.update
+      const actual = await service.update(givenId, givenSpec.modelId, givenSpec);
+
+      // THEN expect repository.update to be called with the spec
+      expect(mockRepository.update).toHaveBeenCalledWith(givenId, givenSpec);
+      // AND expect the returned occupation
+      expect(actual).toEqual(givenUpdatedOccupation);
+    });
+
+    test("should return null if repository.update returns null (occupation not found)", async () => {
+      // GIVEN a full update spec
+      const givenId = getMockStringId(2);
+      const givenSpec = buildSpec();
+
+      // AND the model is not released
+      mockModelRepository.getModelById.mockResolvedValue({
+        id: givenSpec.modelId,
+        released: false,
+      } as unknown as IModelInfo);
+
+      // AND the repository returns null (occupation not found)
+      mockRepository.update = jest.fn().mockResolvedValue(null);
+
+      // WHEN calling service.update
+      const actual = await service.update(givenId, givenSpec.modelId, givenSpec);
+
+      // THEN expect null
+      expect(actual).toBeNull();
+    });
+
+    test("should throw OccupationModelValidationError if model is not found", async () => {
+      // GIVEN a full update spec
+      const givenId = getMockStringId(2);
+      const givenSpec = buildSpec();
+
+      // AND the model does not exist
+      mockModelRepository.getModelById.mockResolvedValue(null);
+
+      // WHEN calling service.update
+      // THEN expect it to throw
+      await expect(service.update(givenId, givenSpec.modelId, givenSpec)).rejects.toThrow(
+        OccupationModelValidationError
+      );
+    });
+
+    test("should throw OccupationModelValidationError if model is released", async () => {
+      // GIVEN a full update spec
+      const givenId = getMockStringId(2);
+      const givenSpec = buildSpec();
+
+      // AND the model is released
+      mockModelRepository.getModelById.mockResolvedValue({
+        id: givenSpec.modelId,
+        released: true,
+      } as unknown as IModelInfo);
+
+      // WHEN calling service.update
+      // THEN expect it to throw
+      await expect(service.update(givenId, givenSpec.modelId, givenSpec)).rejects.toThrow(
+        OccupationModelValidationError
+      );
+    });
+
+    test("should rethrow if repository.update throws", async () => {
+      // GIVEN a full update spec
+      const givenId = getMockStringId(2);
+      const givenSpec = buildSpec();
+
+      // AND the model is not released
+      mockModelRepository.getModelById.mockResolvedValue({
+        id: givenSpec.modelId,
+        released: false,
+      } as unknown as IModelInfo);
+
+      // AND the repository throws
+      const givenError = new Error("Repository error");
+      mockRepository.update = jest.fn().mockRejectedValue(givenError);
+
+      // WHEN calling service.update
+      // THEN expect it to rethrow
+      await expect(service.update(givenId, givenSpec.modelId, givenSpec)).rejects.toThrow(givenError);
+    });
+  });
+
+  describe("patch", () => {
+    test("should call repository.patch with the given partial spec when model validation passes", async () => {
+      // GIVEN a partial patch spec (only preferredLabel)
+      const givenId = getMockStringId(2);
+      const givenModelId = getMockStringId(1);
+      const givenSpec: IPartialUpdateOccupationSpec = { preferredLabel: getRandomString(10) };
+
+      // AND the model is not released
+      mockModelRepository.getModelById.mockResolvedValue({
+        id: givenModelId,
+        released: false,
+      } as unknown as IModelInfo);
+
+      // AND the repository returns the updated occupation
+      const givenUpdatedOccupation: IOccupation = {
+        id: givenId,
+        modelId: givenModelId,
+        UUID: getRandomString(10),
+        preferredLabel: givenSpec.preferredLabel!,
         code: getRandomString(5),
+        altLabels: [],
+        description: getRandomString(10),
+        definition: getRandomString(10),
+        scopeNote: getRandomString(10),
+        regulatedProfessionNote: getRandomString(10),
         occupationType: ObjectTypes.ESCOOccupation,
         isLocalized: false,
+        originUri: getRandomString(10),
+        occupationGroupCode: getRandomString(5),
+        UUIDHistory: [],
+        importId: "",
+        parent: null,
+        children: [],
+        requiresSkills: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
       };
-    }
+      mockRepository.patch = jest.fn().mockResolvedValue(givenUpdatedOccupation);
 
-    function expectedModelReference(model: IModelInfo) {
-      return {
-        id: model.id,
-        UUID: model.UUID,
-        name: model.name,
-        version: model.version,
-        localeShortCode: model.locale.shortCode,
-      };
-    }
+      // WHEN calling service.patch
+      const actual = await service.patch(givenId, givenModelId, givenSpec);
 
-    test("should return null when the occupation does not exist", async () => {
-      // GIVEN the occupation does not exist
-      mockRepository.findById.mockResolvedValue(null);
+      // THEN expect repository.patch to be called with the spec
+      expect(mockRepository.patch).toHaveBeenCalledWith(givenId, givenSpec);
+      // AND expect the returned occupation
+      expect(actual).toEqual(givenUpdatedOccupation);
+    });
 
-      // WHEN calling getHistory
-      const actual = await service.getHistory(getMockStringId(1));
+    test("should return null if repository.patch returns null (occupation not found)", async () => {
+      // GIVEN a partial patch spec
+      const givenId = getMockStringId(2);
+      const givenModelId = getMockStringId(1);
+      const givenSpec: IPartialUpdateOccupationSpec = { description: "Updated" };
 
-      // THEN expect null and no further lookups
+      // AND the model is not released
+      mockModelRepository.getModelById.mockResolvedValue({
+        id: givenModelId,
+        released: false,
+      } as unknown as IModelInfo);
+
+      // AND the repository returns null
+      mockRepository.patch = jest.fn().mockResolvedValue(null);
+
+      // WHEN calling service.patch
+      const actual = await service.patch(givenId, givenModelId, givenSpec);
+
+      // THEN expect null
       expect(actual).toBeNull();
-      expect(mockRepository.findHistoryReferencesByUUIDs).not.toHaveBeenCalled();
-      expect(mockModelRepository.getModelsByIds).not.toHaveBeenCalled();
     });
 
-    test("should return an empty array when the occupation has an empty UUIDHistory", async () => {
-      // GIVEN an occupation with an empty UUIDHistory
-      mockRepository.findById.mockResolvedValue({ UUIDHistory: [] } as unknown as IOccupation);
+    test("should throw OccupationModelValidationError if model is released", async () => {
+      // GIVEN a partial patch spec
+      const givenId = getMockStringId(2);
+      const givenModelId = getMockStringId(1);
+      const givenSpec: IPartialUpdateOccupationSpec = { preferredLabel: "Label" };
 
-      // WHEN calling getHistory
-      const actual = await service.getHistory(getMockStringId(1));
+      // AND the model is released
+      mockModelRepository.getModelById.mockResolvedValue({
+        id: givenModelId,
+        released: true,
+      } as unknown as IModelInfo);
 
-      // THEN expect an empty array and no further lookups
-      expect(actual).toEqual([]);
-      expect(mockRepository.findHistoryReferencesByUUIDs).not.toHaveBeenCalled();
-      expect(mockModelRepository.getModelsByIds).not.toHaveBeenCalled();
+      // WHEN calling service.patch
+      // THEN expect it to throw
+      await expect(service.patch(givenId, givenModelId, givenSpec)).rejects.toThrow(OccupationModelValidationError);
     });
 
-    test("should resolve entity ref + stripped model per UUID, preserve UUIDHistory order, and skip unresolved UUIDs", async () => {
-      // GIVEN an occupation whose own UUIDHistory has two resolvable UUIDs with a non-existent one in between
-      const givenUuidA = randomUUID();
-      const givenUuidMissing = randomUUID();
-      const givenUuidB = randomUUID();
-      mockRepository.findById.mockResolvedValue({
-        UUIDHistory: [givenUuidA, givenUuidMissing, givenUuidB],
-      } as unknown as IOccupation);
+    test("should throw OccupationModelValidationError if model is not found", async () => {
+      // GIVEN a partial patch spec
+      const givenId = getMockStringId(2);
+      const givenModelId = getMockStringId(1);
+      const givenSpec: IPartialUpdateOccupationSpec = { preferredLabel: "Label" };
 
-      // AND uuidA/uuidB resolve to occupation references in models A and B (missing UUID resolves to nulls)
-      const givenModelAId = getMockStringId(10);
-      const givenModelBId = getMockStringId(20);
-      const givenRefA = givenReference(givenUuidA);
-      const givenRefB = givenReference(givenUuidB);
-      mockRepository.findHistoryReferencesByUUIDs.mockResolvedValue([
-        { UUID: givenUuidA, modelId: givenModelAId, reference: givenRefA },
-        { UUID: givenUuidMissing, modelId: null, reference: null },
-        { UUID: givenUuidB, modelId: givenModelBId, reference: givenRefB },
-      ]);
+      // AND the model does not exist
+      mockModelRepository.getModelById.mockResolvedValue(null);
 
-      // AND the models are fetched by id (returned out of order to prove ordering comes from UUIDHistory)
-      const givenModelA = givenModelWithId(1, givenModelAId);
-      const givenModelB = givenModelWithId(2, givenModelBId);
-      mockModelRepository.getModelsByIds.mockResolvedValue([givenModelB, givenModelA]);
-
-      // WHEN calling getHistory
-      const actual = await service.getHistory(getMockStringId(1));
-
-      // THEN expect one entry per resolvable UUID in UUIDHistory order (A before B), missing skipped
-      expect(actual).toEqual([
-        { entity: givenRefA, model: expectedModelReference(givenModelA) },
-        { entity: givenRefB, model: expectedModelReference(givenModelB) },
-      ]);
-      // AND resolution uses single batched queries (no N+1): UUIDs -> refs+modelIds, then modelIds -> models
-      expect(mockRepository.findHistoryReferencesByUUIDs).toHaveBeenCalledTimes(1);
-      expect(mockRepository.findHistoryReferencesByUUIDs).toHaveBeenCalledWith([
-        givenUuidA,
-        givenUuidMissing,
-        givenUuidB,
-      ]);
-      expect(mockModelRepository.getModelsByIds).toHaveBeenCalledTimes(1);
-      expect(mockModelRepository.getModelsByIds).toHaveBeenCalledWith([givenModelAId, givenModelBId]);
-      // AND the heavy model.getHistory is NOT used anymore
-      expect(mockModelRepository.getHistory).not.toHaveBeenCalled();
+      // WHEN calling service.patch
+      // THEN expect it to throw
+      await expect(service.patch(givenId, givenModelId, givenSpec)).rejects.toThrow(OccupationModelValidationError);
     });
 
-    test("should return a model at most once even if several history UUIDs map to the same model", async () => {
-      // GIVEN two of the occupation's historical UUIDs resolve to the SAME model
-      const givenUuid1 = randomUUID();
-      const givenUuid2 = randomUUID();
-      mockRepository.findById.mockResolvedValue({ UUIDHistory: [givenUuid1, givenUuid2] } as unknown as IOccupation);
-      const givenModelId = getMockStringId(10);
-      mockRepository.findHistoryReferencesByUUIDs.mockResolvedValue([
-        { UUID: givenUuid1, modelId: givenModelId, reference: givenReference(givenUuid1) },
-        { UUID: givenUuid2, modelId: givenModelId, reference: givenReference(givenUuid2) },
-      ]);
-      const givenModel = givenModelWithId(1, givenModelId);
-      mockModelRepository.getModelsByIds.mockResolvedValue([givenModel]);
+    test("should rethrow if repository.patch throws", async () => {
+      // GIVEN a partial patch spec
+      const givenId = getMockStringId(2);
+      const givenModelId = getMockStringId(1);
+      const givenSpec: IPartialUpdateOccupationSpec = { preferredLabel: "Label" };
 
-      // WHEN calling getHistory
-      const actual = await service.getHistory(getMockStringId(1));
+      // AND the model is not released
+      mockModelRepository.getModelById.mockResolvedValue({
+        id: givenModelId,
+        released: false,
+      } as unknown as IModelInfo);
 
-      // THEN the model appears only once (the first history UUID that maps to it wins)
-      expect(actual).toHaveLength(1);
-      expect(actual![0].model).toEqual(expectedModelReference(givenModel));
-    });
+      // AND the repository throws
+      const givenError = new Error("Repository patch error");
+      mockRepository.patch = jest.fn().mockRejectedValue(givenError);
 
-    test("should skip a UUID whose model no longer exists", async () => {
-      // GIVEN a UUID that resolves to a reference + modelId, but the model itself is gone
-      const givenUuid = randomUUID();
-      const givenModelId = getMockStringId(10);
-      mockRepository.findById.mockResolvedValue({ UUIDHistory: [givenUuid] } as unknown as IOccupation);
-      mockRepository.findHistoryReferencesByUUIDs.mockResolvedValue([
-        { UUID: givenUuid, modelId: givenModelId, reference: givenReference(givenUuid) },
-      ]);
-      mockModelRepository.getModelsByIds.mockResolvedValue([]); // model not found
-
-      // WHEN calling getHistory
-      const actual = await service.getHistory(getMockStringId(1));
-
-      // THEN the entry is skipped
-      expect(actual).toEqual([]);
+      // WHEN calling service.patch
+      // THEN expect it to rethrow
+      await expect(service.patch(givenId, givenModelId, givenSpec)).rejects.toThrow(givenError);
     });
   });
 });

--- a/backend/src/esco/occupations/services/occupation.service.ts
+++ b/backend/src/esco/occupations/services/occupation.service.ts
@@ -183,7 +183,7 @@ export class OccupationService implements IOccupationService {
     if (errorCode != null) {
       throw new OccupationModelValidationError(errorCode);
     }
-    return this.occupationRepository.update(id, spec);
+    return this.occupationRepository.update(id, modelId, spec);
   }
 
   async patch(id: string, modelId: string, spec: IPartialUpdateOccupationSpec): Promise<IOccupation | null> {
@@ -191,6 +191,6 @@ export class OccupationService implements IOccupationService {
     if (errorCode != null) {
       throw new OccupationModelValidationError(errorCode);
     }
-    return this.occupationRepository.patch(id, spec);
+    return this.occupationRepository.patch(id, modelId, spec);
   }
 }

--- a/backend/src/esco/occupations/services/occupation.service.ts
+++ b/backend/src/esco/occupations/services/occupation.service.ts
@@ -5,7 +5,12 @@ import {
   ModelForOccupationValidationErrorCode,
   OccupationModelValidationError,
 } from "./occupation.service.types";
-import { INewOccupationSpecWithoutImportId, IOccupation } from "../_shared/occupation.types";
+import {
+  INewOccupationSpecWithoutImportId,
+  IOccupation,
+  IPartialUpdateOccupationSpec,
+  IUpdateOccupationSpec,
+} from "../_shared/occupation.types";
 import { IOccupationRepository } from "../repository/occupation.repository";
 import { IModelRepository } from "modelInfo/modelInfoRepository";
 import { toModelReference } from "modelInfo/modelInfoReference";
@@ -138,33 +143,25 @@ export class OccupationService implements IOccupationService {
     };
   }
 
+<<<<<<< HEAD
   async getHistory(occupationId: string): Promise<IOccupationHistoryEntry[] | null> {
     const occupation = await this.occupationRepository.findById(occupationId);
     if (!occupation) {
       return null;
     }
 
-    // The occupation's UUIDHistory holds the occupation's OWN past UUIDs (one per model it existed in),
-    // newest first. To describe the occupation as it appeared in each model we resolve:
-    // UUID -> occupation entity reference + its modelId -> a stripped-down reference to that model.
     const uuidHistory = occupation.UUIDHistory ?? [];
-    if (uuidHistory.length === 0) {
-      return [];
-    }
+    if (uuidHistory.length === 0) return [];
 
-    // Resolve each historical UUID to the occupation's reference (as it was in that model) + its modelId.
     const historyReferences = await this.occupationRepository.findHistoryReferencesByUUIDs(uuidHistory);
     const referenceByUUID = new Map(historyReferences.map((entry) => [entry.UUID, entry]));
 
-    // Fetch the models for the resolved modelIds (single query) and map them to lightweight references.
     const modelIds = Array.from(
       new Set(historyReferences.map((entry) => entry.modelId).filter((id): id is string => id !== null))
     );
     const resolvedModels = modelIds.length > 0 ? await this.modelRepository.getModelsByIds(modelIds) : [];
     const modelById = new Map(resolvedModels.map((model) => [model.id, model]));
 
-    // Walk the occupation's UUIDHistory (newest first), skipping UUIDs whose occupation or model no longer exists.
-    // A given model appears at most once even if multiple history UUIDs map to it.
     const history: IOccupationHistoryEntry[] = [];
     const seenModelIds = new Set<string>();
     for (const uuid of uuidHistory) {
@@ -173,13 +170,27 @@ export class OccupationService implements IOccupationService {
         continue;
       }
       const model = modelById.get(entry.modelId);
-      if (!model) {
-        continue;
-      }
+      if (!model) continue;
       seenModelIds.add(entry.modelId);
       history.push({ entity: entry.reference, model: toModelReference(model) });
     }
 
     return history;
+  }
+
+  async update(id: string, modelId: string, spec: IUpdateOccupationSpec): Promise<IOccupation | null> {
+    const errorCode = await this.validateModelForOccupation(modelId);
+    if (errorCode != null) {
+      throw new OccupationModelValidationError(errorCode);
+    }
+    return this.occupationRepository.update(id, spec);
+  }
+
+  async patch(id: string, modelId: string, spec: IPartialUpdateOccupationSpec): Promise<IOccupation | null> {
+    const errorCode = await this.validateModelForOccupation(modelId);
+    if (errorCode != null) {
+      throw new OccupationModelValidationError(errorCode);
+    }
+    return this.occupationRepository.patch(id, spec);
   }
 }

--- a/backend/src/esco/occupations/services/occupation.service.ts
+++ b/backend/src/esco/occupations/services/occupation.service.ts
@@ -143,7 +143,6 @@ export class OccupationService implements IOccupationService {
     };
   }
 
-<<<<<<< HEAD
   async getHistory(occupationId: string): Promise<IOccupationHistoryEntry[] | null> {
     const occupation = await this.occupationRepository.findById(occupationId);
     if (!occupation) {

--- a/backend/src/esco/occupations/services/occupation.service.types.ts
+++ b/backend/src/esco/occupations/services/occupation.service.types.ts
@@ -1,16 +1,13 @@
 import { IOccupationGroup } from "esco/occupationGroup/_shared/OccupationGroup.types";
-import { INewOccupationSpecWithoutImportId, IOccupation, ISkillWithRelation } from "../_shared/occupation.types";
+import {
+  INewOccupationSpecWithoutImportId,
+  IOccupation,
+  IPartialUpdateOccupationSpec,
+  ISkillWithRelation,
+  IUpdateOccupationSpec,
+} from "../_shared/occupation.types";
+import { IOccupationReference } from "esco/occupations/_shared/occupationReference.types";
 import { IModelInfoReference } from "modelInfo/modelInfo.types";
-import { IOccupationReference } from "../_shared/occupationReference.types";
-
-/**
- * A single entry of an occupation's model history: the occupation's reference (as it appeared in that model)
- * together with a lightweight reference to the model it belonged to.
- */
-export interface IOccupationHistoryEntry {
-  entity: IOccupationReference;
-  model: IModelInfoReference;
-}
 
 export enum ModelForOccupationValidationErrorCode {
   FAILED_TO_FETCH_FROM_DB,
@@ -27,35 +24,24 @@ export class OccupationModelValidationError extends Error {
 // Re-export for consumers that import ISkillWithRelation from here
 export type { ISkillWithRelation };
 
+/**
+ * A single entry of an occupation's model history: the occupation's reference (as it appeared in that model)
+ * together with a lightweight reference to the model it belonged to.
+ */
+export interface IOccupationHistoryEntry {
+  entity: IOccupationReference;
+  model: IModelInfoReference;
+}
+
 export interface IOccupationService {
   /**
    * Creates a new Occupation entry.
-   *
-   * @param {INewOccupationSpecWithoutImportId} newOccupationSpec - The specification for the new Occupation entry.
-   * @return {Promise<IOccupation>} - A Promise that resolves to the newly created Occupation entry.
-   * Rejects with an error if the Occupation entry cannot be created due to reasons other than validation.
    */
   create(newOccupationSpec: INewOccupationSpecWithoutImportId): Promise<IOccupation>;
 
-  /**
-   * Finds an Occupation entry by its ID.
-   *
-   * @param {string} id - The unique ID of the Occupation entry.
-   * @return {Promise<IOccupation|null>} - A Promise that resolves to the found Occupation entry or null if not found.
-   * Rejects with an error if the operation fails.
-   */
+  /** Finds an Occupation entry by its ID. */
   findById(id: string): Promise<IOccupation | null>;
 
-  /**
-   * Returns paginated Occupations. The Occupations are transformed to objects (via .lean()), however
-   * in the current version they are not populated with parents or children. This will be implemented in a future version.
-   * @param {string} modelId - The modelId of the Occupations.
-   * @param {object} cursor - The cursor for pagination.
-   * @param {number} limit - The maximum number of Occupations to return.
-   * @param {boolean} [desc] - Whether to sort the results in descending order. Default is true.
-   * @return {Promise<{items: IOccupation[], nextCursor: {_id: string, createdAt: Date} | null}>} - An array of IOccupations and the next cursor (if any)
-   * Rejects with an error if the operation fails.
-   */
   findPaginated(
     modelId: string,
     cursor: { id: string; createdAt: Date } | undefined,
@@ -63,31 +49,10 @@ export interface IOccupationService {
     desc?: boolean
   ): Promise<{ items: IOccupation[]; nextCursor: { _id: string; createdAt: Date } | null }>;
 
-  /**
-   * Validates that a model exists and is not released for occupation creation
-   * @param {string} modelId - The model ID to validate
-   * @return {Promise<ModelForOccupationValidationErrorCode | null>} - Returns null if valid, otherwise the error code
-   */
   validateModelForOccupation(modelId: string): Promise<ModelForOccupationValidationErrorCode | null>;
 
-  /**
-   * Finds the parent Occupation or OccupationGroup of an Occupation.
-   *
-   * @param {string} modelId - The modelId of the Occupation.
-   * @param {string} occupationId - The ID of the Occupation.
-   * @return {Promise<IOccupation | IOccupationGroup | null>} - A Promise that resolves to the parent Occupation or OccupationGroup, or null if unrelated.
-   */
   getParent(modelId: string, occupationId: string): Promise<IOccupation | IOccupationGroup | null>;
 
-  /**
-   * Finds the child Occupations of an Occupation.
-   *
-   * @param {string} modelId - The modelId of the Occupation.
-   * @param {string} occupationId - The ID of the Occupation.
-   * @param {string} cursor - The cursor for pagination.
-   * @param {number} limit - The maximum number of Occupations to return.
-   * @return {Promise<{items: IOccupation[], nextCursor: {_id: string, createdAt: Date} | null}>} - An array of IOccupations and the next cursor (if any)
-   */
   getChildren(
     modelId: string,
     occupationId: string,
@@ -95,15 +60,6 @@ export interface IOccupationService {
     limit: number
   ): Promise<{ items: IOccupation[]; nextCursor: { _id: string; createdAt: Date } | null }>;
 
-  /**
-   * Finds the skills required by an Occupation with relationship metadata.
-   *
-   * @param {string} modelId - The modelId of the Occupation.
-   * @param {string} occupationId - The ID of the Occupation.
-   * @param {string} cursor - The cursor for pagination.
-   * @param {number} limit - The maximum number of skills to return.
-   * @return {Promise<{items: ISkillWithRelation[], nextCursor: {_id: string, createdAt: Date} | null}>} - An array of skills with relationship metadata and the next cursor (if any)
-   */
   getSkills(
     modelId: string,
     occupationId: string,
@@ -112,14 +68,21 @@ export interface IOccupationService {
   ): Promise<{ items: ISkillWithRelation[]; nextCursor: { _id: string; createdAt: Date } | null }>;
 
   /**
+   * Fully replaces the mutable fields of an Occupation (PUT semantics).
+   * Validates that the model exists and is not released before updating.
+   */
+  update(id: string, modelId: string, spec: IUpdateOccupationSpec): Promise<IOccupation | null>;
+
+  /**
+   * Partially updates an Occupation (PATCH semantics).
+   */
+  patch(id: string, modelId: string, spec: IPartialUpdateOccupationSpec): Promise<IOccupation | null>;
+
+  /**
    * Resolves the history of the models an Occupation appeared in, based on its UUIDHistory.
    * For each UUID in the occupation's UUIDHistory (newest first) that resolves to an existing model,
-   * returns the full model together with the details of that model's own UUIDHistory. UUIDs that do
-   * not resolve to an existing model are skipped.
-   *
-   * @param {string} occupationId - The ID of the Occupation.
-   * @return {Promise<IOccupationHistoryEntry[] | null>} - The resolved history entries in UUIDHistory order,
-   * or null if the Occupation does not exist.
+   * returns the model reference and the occupation reference as it appeared in that model.
+   * UUIDs that do not resolve to an existing model are skipped.
    */
   getHistory(occupationId: string): Promise<IOccupationHistoryEntry[] | null>;
 }

--- a/backend/src/export/esco/occupation/OccupationsToCSVTransform.test.ts
+++ b/backend/src/export/esco/occupation/OccupationsToCSVTransform.test.ts
@@ -51,6 +51,8 @@ function setupOccupationRepositoryMock(findAllImpl: () => Readable) {
     findParent: jest.fn(),
     findChildren: jest.fn(),
     findSkillsForOccupation: jest.fn(),
+    update: jest.fn(),
+    patch: jest.fn(),
   };
   OccupationRepositorySpy.mockReturnValue(mockOccupationRepository);
 }

--- a/backend/src/import/async/parseFiles.test.ts
+++ b/backend/src/import/async/parseFiles.test.ts
@@ -472,6 +472,8 @@ describe("Test the main async handler", () => {
         findParent: jest.fn(),
         findChildren: jest.fn(),
         findSkillsForOccupation: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
       };
       jest.spyOn(getRepositoryRegistry(), "occupation", "get").mockReturnValue(givenOccupationRepositoryMock);
       // AND a skill repository

--- a/backend/src/import/esco/occupations/occupationsParser.test.ts
+++ b/backend/src/import/esco/occupations/occupationsParser.test.ts
@@ -100,6 +100,8 @@ describe("test parseOccupations from", () => {
         findParent: jest.fn(),
         findChildren: jest.fn(),
         findSkillsForOccupation: jest.fn(),
+        update: jest.fn(),
+        patch: jest.fn(),
       };
       // @ts-ignore
       jest.spyOn(getRepositoryRegistry(), "occupation", "get").mockReturnValue(mockRepository);

--- a/backend/src/validator.ts
+++ b/backend/src/validator.ts
@@ -118,6 +118,22 @@ ajvInstance.addSchema(
   OccupationAPISpecs.Occupation.Skills.GET.Schemas.Request.Query.Payload.$id
 );
 ajvInstance.addSchema(
+  OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload,
+  OccupationAPISpecs.Occupation.PUT.Schemas.Request.Payload.$id
+);
+ajvInstance.addSchema(
+  OccupationAPISpecs.Occupation.PUT.Schemas.Response.Payload,
+  OccupationAPISpecs.Occupation.PUT.Schemas.Response.Payload.$id
+);
+ajvInstance.addSchema(
+  OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload,
+  OccupationAPISpecs.Occupation.PATCH.Schemas.Request.Payload.$id
+);
+ajvInstance.addSchema(
+  OccupationAPISpecs.Occupation.PATCH.Schemas.Response.Payload,
+  OccupationAPISpecs.Occupation.PATCH.Schemas.Response.Payload.$id
+);
+ajvInstance.addSchema(
   SkillGroupAPISpecs.POST.Schemas.Request.Payload,
   SkillGroupAPISpecs.POST.Schemas.Request.Payload.$id
 );


### PR DESCRIPTION
This pull request contains
- implement PATCH and PUT API specifications for occupations with associated schema validations and tests
- implemented backend api for the prvided api spec